### PR TITLE
Allow GitHub Pages builds to auto-detect base path

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
-VITE_BASE_URL=/show-app-preview/
+# Intentionally left blank so that Vite auto-detects the correct base path during builds.
+# Define VITE_BASE_URL here only when you need to override the computed value.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,9 +6,18 @@ import AnalyticsPage from '../Pages/Analytics';
 
 const routerBasename = (() => {
   const baseUrl = import.meta.env.BASE_URL || '/';
-  if (baseUrl === '/') {
-    return undefined;
+  const normalizedBase = baseUrl.replace(/\/+$/, '/');
+
+  if (normalizedBase === '/' || normalizedBase === './') {
+    const pathSegments = window.location.pathname.split('/').filter(Boolean);
+    if (pathSegments.length === 0) {
+      return undefined;
+    }
+
+    const repositoryBase = `/${pathSegments[0]}`;
+    return repositoryBase === '/' ? undefined : repositoryBase;
   }
+
   return baseUrl.replace(/\/+$/, '') || undefined;
 })();
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -5,10 +5,11 @@ import { fileURLToPath, URL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
-  const repository = env.GITHUB_REPOSITORY?.split('/')?.pop();
-  const base = env.VITE_BASE_URL || (repository ? `/${repository}/` : '/');
+  const repository = process.env.GITHUB_REPOSITORY?.split('/')?.pop();
+  const defaultBuildBase = repository ? `/${repository}/` : './';
+  const base = env.VITE_BASE_URL || (command === 'build' ? defaultBuildBase : '/');
 
   return {
     base,

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -9,7 +9,20 @@ export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const repository = process.env.GITHUB_REPOSITORY?.split('/')?.pop();
   const defaultBuildBase = repository ? `/${repository}/` : './';
-  const base = env.VITE_BASE_URL || (command === 'build' ? defaultBuildBase : '/');
+
+  const explicitBase = env.VITE_BASE_URL?.trim();
+  const normalizedExplicitBase = (() => {
+    if (!explicitBase) return undefined;
+
+    const withTrailingSlash = explicitBase.endsWith('/') ? explicitBase : `${explicitBase}/`;
+    if (withTrailingSlash.startsWith('/') || withTrailingSlash.startsWith('./')) {
+      return withTrailingSlash;
+    }
+
+    return `/${withTrailingSlash}`;
+  })();
+
+  const base = normalizedExplicitBase ?? (command === 'build' ? defaultBuildBase : '/');
 
   return {
     base,


### PR DESCRIPTION
## Summary
- remove the forced VITE_BASE_URL override so GitHub Pages builds can compute the repository subpath automatically

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e669782330832f9b32786b5e029ec8