### PR TITLE
Make Husky hook setup optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Deze repository bevat een GitHub Actions workflow die automatisch een productieb
 2. Ga naar het tabblad **Actions** om de workflow `Deploy to GitHub Pages` te volgen.
 3. Na een geslaagde run staat de site live op `https://jouw-github-gebruikersnaam.github.io/show-app-preview/`.
 
+## Git-hooks voor ontwikkelaars
+
+Husky-hooks worden niet automatisch tijdens `npm install` geconfigureerd, zodat installaties ook zonder Git blijven werken. Wil je lokaal pre-commit- en pre-push-hooks gebruiken, voer dan na het clonen:
+
+```bash
+npm run setup:hooks
+```
+
+Het script slaat de installatie over als Git niet beschikbaar is.
+
 ## Docker
 
 Deze repository bevat een multi-stage Dockerfile die eerst de Vite-frontend bouwt en vervolgens dezelfde container gebruikt om de backend-API én de gebuilde statics te serveren.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "lint:fix": "eslint . --ext .ts,.tsx,.js,.jsx --fix",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
-    "prepare": "husky install",
+    "setup:hooks": "command -v git >/dev/null 2>&1 && husky install || echo \"Git niet gevonden; Husky-installatie overgeslagen\"",
     "prepush": "npm run typecheck",
     "lint-staged": "npx lint-staged",
     "smoke:test": "USE_STUB_API=true node -r ts-node/register/transpile-only ./scripts/smoke/smoke-render.ts",


### PR DESCRIPTION
## Summary
- remove the automatic Husky `prepare` step and add an opt-in hook setup script
- document how to enable Git hooks locally while keeping installs working without Git

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926f1594c9c832f9f50cf060500d068)