### PR TITLE
Add configurable base URL and simplify static serving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,10 @@ COPY . .
 # Allow the API base to be configured at build-time
 ARG VITE_API_BASE=http://localhost:4000/api
 ARG VITE_USE_STUB_API=false
+ARG VITE_BASE_URL=/
 ENV VITE_API_BASE=${VITE_API_BASE}
 ENV VITE_USE_STUB_API=${VITE_USE_STUB_API}
+ENV VITE_BASE_URL=${VITE_BASE_URL}
 
 RUN npm run build
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Deze repository bevat een multi-stage Dockerfile die eerst de Vite-frontend bouw
 | Variabele           | Beschrijving                                                    | Standaard                    |
 | ------------------- | --------------------------------------------------------------- | ---------------------------- |
 | `VITE_API_BASE`     | API-basis-URL tijdens het bouwen van de frontend.               | `http://localhost:4000/api`  |
+| `VITE_BASE_URL`     | Basis-URL waaronder de frontend wordt gehost tijdens runtime.   | `/`                          |
 | `VITE_USE_STUB_API` | Gebruik de stub-API in de frontend (`true`/`false`).            | `false`                      |
 | `PORT`              | Poort waarop de backend luistert.                               | `4000`                       |
 | `CLIENT_ORIGIN`     | Toegestane CORS-origin (leeg laat alle origins toe).            | _leeg_                       |
@@ -36,12 +37,15 @@ Deze repository bevat een multi-stage Dockerfile die eerst de Vite-frontend bouw
 | `UPLOAD_DIR`        | Locatie op de host/container waar uploads worden opgeslagen.    | `/data/uploads`              |
 | `DATABASE_URL`      | Database connectiestring (placeholder voor toekomstige opslag). | `file:./data/exhibit.sqlite` |
 
+Laat `VITE_BASE_URL` leeg om automatisch terug te vallen op de root (`/`).
+
 ### Image bouwen en draaien
 
 1. Build de image met optionele build-args voor de frontend:
    ```bash
    docker build \
      --build-arg VITE_API_BASE="https://api.example.com" \
+     --build-arg VITE_BASE_URL="/" \
      --build-arg VITE_USE_STUB_API=false \
      -t exhibit .
    ```
@@ -68,5 +72,5 @@ Pas eventueel de waarden in een `.env`-bestand aan om `PORT`, `VITE_API_BASE`, `
 ### Deployen naar Sliplane
 
 - Wijs in Sliplane de map met deze repository aan en kies de meegeleverde `Dockerfile` als build-instructie.
-- Zet de gewenste omgeving variabelen (`PORT`, `CLIENT_ORIGIN`, `DATABASE_URL`, `VITE_API_BASE`) in het Sliplane-dashboard.
+- Zet de gewenste omgeving variabelen (`PORT`, `CLIENT_ORIGIN`, `DATABASE_URL`, `VITE_API_BASE`, `VITE_BASE_URL`) in het Sliplane-dashboard. Laat `VITE_BASE_URL` leeg of op `/` voor een root-deploy.
 - Zorg dat poort `4000` (of de ingestelde waarde) wordt blootgesteld in de Sliplane service-instellingen.

--- a/backend/server.js
+++ b/backend/server.js
@@ -28,7 +28,6 @@ app.use('/uploads', express.static(uploadDir));
 
 if (fs.existsSync(staticDir)) {
   app.use(express.static(staticDir));
-  app.use('/show-app-preview', express.static(staticDir));
 }
 
 const storage = multer.diskStorage({

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -6,7 +6,8 @@ import { fileURLToPath, URL } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(() => {
-  const base = '/';
+  // Fall back to the root when no build-time base is provided.
+  const base = process.env.VITE_BASE_URL?.trim() || '/';
 
   return {
     base,


### PR DESCRIPTION
## Summary
- allow configuring Vite's `base` via `VITE_BASE_URL` with a default root fallback and document the behavior
- propagate the base URL into the Docker build environment for Sliplane and other builds
- remove the redundant `/show-app-preview` static mount and rebuild the production assets

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692708454cc8832f9f7e89a0cee430f1)