### PR TITLE
Update server wildcard route for SPA fallback

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -116,7 +116,7 @@ app.post('/api/uploads', upload.single('file'), (req, res) => {
   res.status(201).json({ file_url: fileUrl });
 });
 
-app.get('/{*splat}', (req, res, next) => {
+app.get('*', (req, res, next) => {
   if (
     req.path.startsWith('/api') ||
     req.path.startsWith('/uploads') ||


### PR DESCRIPTION
## Summary
- replace the Express catch-all route with a standard wildcard fallback for SPA routing
- continue excluding API, uploads, and assets paths while serving the Vite-built index.html for client routes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692712f9ab90832fb0960457bd1fef0d)