### PR TITLE
Fix SPA fallback route regex

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -116,21 +116,13 @@ app.post('/api/uploads', upload.single('file'), (req, res) => {
   res.status(201).json({ file_url: fileUrl });
 });
 
-app.get('/{*splat}', (req, res, next) => {
-  if (
-    req.path.startsWith('/api') ||
-    req.path.startsWith('/uploads') ||
-    req.path.startsWith('/assets')
-  ) {
-    return next();
-  }
-
+app.get(/^\/(?!api|uploads|assets).*$/, (req, res, next) => {
   const indexPath = path.join(staticDir, 'index.html');
   if (fs.existsSync(indexPath)) {
     return res.sendFile(indexPath);
   }
 
-  return res.status(404).send('Not found');
+  return next();
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- adjust SPA fallback to use a regex route compatible with Express 5
- continue serving index.html for non-API and non-static paths while letting assets/uploads bypass

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692712f9ab90832fb0960457bd1fef0d)