### PR TITLE
Update catch-all route for Express 5 compatibility

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -116,7 +116,7 @@ app.post('/api/uploads', upload.single('file'), (req, res) => {
   res.status(201).json({ file_url: fileUrl });
 });
 
-app.get('*', (req, res, next) => {
+app.get('/{*splat}', (req, res, next) => {
   if (
     req.path.startsWith('/api') ||
     req.path.startsWith('/uploads') ||


### PR DESCRIPTION
## Summary
- update the frontend catch-all route to use an Express 5 compatible named wildcard path
- keep existing exclusions for API, uploads, and assets before serving the SPA index
- continue serving index.html when available and return 404 otherwise

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692718eaf540832f894f0e98f9a9cf0b)