### PR TITLE
Use configurable relative API base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN npm ci
 COPY . .
 
 # Allow the API base to be configured at build-time
-ARG VITE_API_BASE=http://localhost:4000/api
+ARG VITE_API_BASE=/api
 ARG VITE_USE_STUB_API=false
 ARG VITE_BASE_URL=/
 ENV VITE_API_BASE=${VITE_API_BASE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        VITE_API_BASE: ${VITE_API_BASE:-http://localhost:4000/api}
+        VITE_API_BASE: ${VITE_API_BASE:-/api}
         VITE_USE_STUB_API: ${VITE_USE_STUB_API:-false}
     environment:
       PORT: ${PORT:-4000}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,16 +1,16 @@
-const defaultBase =
-  typeof process !== 'undefined' && process.env.VITE_API_BASE
-    ? process.env.VITE_API_BASE
-    : 'http://localhost:4000/api';
 const envBase =
   typeof import.meta !== 'undefined' && import.meta.env?.VITE_API_BASE
     ? import.meta.env.VITE_API_BASE
+    : undefined;
+const ssrBase =
+  typeof process !== 'undefined' && process.env.VITE_API_BASE
+    ? process.env.VITE_API_BASE
     : undefined;
 const useStubApi =
   (typeof process !== 'undefined' && process.env.USE_STUB_API === 'true') ||
   (typeof import.meta !== 'undefined' && import.meta.env?.VITE_USE_STUB_API === 'true');
 
-const API_BASE = envBase || defaultBase;
+const API_BASE = envBase || ssrBase || '/api';
 
 const stubState = {
   user: {


### PR DESCRIPTION
## Summary
- derive the API base URL from environment variables with a safe '/api' default
- update Docker build arguments and compose configuration to pass the configurable API base

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692733090338832f88ace9d3b8c9bae9)