### PR TITLE
Remove stub API support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,8 @@ COPY . .
 
 # Allow the API base to be configured at build-time
 ARG VITE_API_BASE=/api
-ARG VITE_USE_STUB_API=false
 ARG VITE_BASE_URL=/
 ENV VITE_API_BASE=${VITE_API_BASE}
-ENV VITE_USE_STUB_API=${VITE_USE_STUB_API}
 ENV VITE_BASE_URL=${VITE_BASE_URL}
 
 RUN npm run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       context: .
       args:
         VITE_API_BASE: ${VITE_API_BASE:-/api}
-        VITE_USE_STUB_API: ${VITE_USE_STUB_API:-false}
     environment:
       PORT: ${PORT:-4000}
       CLIENT_ORIGIN: ${CLIENT_ORIGIN:-}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "setup:hooks": "command -v git >/dev/null 2>&1 && husky install || echo \"Git niet gevonden; Husky-installatie overgeslagen\"",
     "prepush": "npm run typecheck",
     "lint-staged": "npx lint-staged",
-    "smoke:test": "USE_STUB_API=true node -r ts-node/register/transpile-only ./scripts/smoke/smoke-render.ts",
-    "smoke:test:cjs": "USE_STUB_API=true node ./scripts/smoke/smoke-render.cjs"
+    "smoke:test": "node -r ts-node/register/transpile-only ./scripts/smoke/smoke-render.ts",
+    "smoke:test:cjs": "node ./scripts/smoke/smoke-render.cjs"
   },
   "devDependencies": {
     "@types/node": "20.11.1",

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -6,34 +6,8 @@ const ssrBase =
   typeof process !== 'undefined' && process.env.VITE_API_BASE
     ? process.env.VITE_API_BASE
     : undefined;
-const useStubApi =
-  (typeof process !== 'undefined' && process.env.USE_STUB_API === 'true') ||
-  (typeof import.meta !== 'undefined' && import.meta.env?.VITE_USE_STUB_API === 'true');
 
 const API_BASE = envBase || ssrBase || '/api';
-
-const stubState = {
-  user: {
-    email: 'stub@exhibit.local',
-    display_name: 'Stub User',
-    avatar_url: '',
-    bio: 'Creatief visionair',
-    roles: ['model'],
-    instagram: '@stub',
-    show_sensitive_content: false,
-  },
-  posts: [
-    {
-      id: 'post1',
-      title: 'Stub post',
-      created_by: 'stub@exhibit.local',
-      photography_style: 'portrait',
-      image_url: '/static/stub-image.jpg',
-    },
-  ],
-  likes: [{ id: 'like1', post_id: 'post1', user_email: 'stub@exhibit.local' }],
-  savedPosts: [{ id: 'save1', post_id: 'post1', user_email: 'stub@exhibit.local' }],
-};
 
 async function request(path, options = {}) {
   const response = await fetch(`${API_BASE}${path}`, {
@@ -51,63 +25,34 @@ async function request(path, options = {}) {
   return response.json();
 }
 
-function applyFilter(collection, filter) {
-  return collection.filter((item) =>
-    Object.entries(filter || {}).every(([key, value]) => {
-      if (typeof value === 'object' && value !== null && '$in' in value) {
-        return value.$in.includes(item[key]);
-      }
-      return item[key] === value;
-    }),
-  );
-}
-
 export async function fetchCurrentUser() {
-  if (useStubApi) return stubState.user;
   return request('/users/me');
 }
 
 export async function updateCurrentUser(payload) {
-  if (useStubApi) {
-    stubState.user = { ...stubState.user, ...payload };
-    return stubState.user;
-  }
   return request('/users/me', { method: 'PATCH', body: JSON.stringify(payload) });
 }
 
 export async function filterPosts(filter) {
-  if (useStubApi) return applyFilter(stubState.posts, filter);
   return request('/posts/filter', { method: 'POST', body: JSON.stringify(filter) });
 }
 
 export async function createPost(payload) {
-  if (useStubApi) {
-    const newPost = { id: `post-${Date.now()}`, ...payload };
-    stubState.posts.unshift(newPost);
-    return newPost;
-  }
   return request('/posts', { method: 'POST', body: JSON.stringify(payload) });
 }
 
 export async function filterLikes(filter) {
-  if (useStubApi) return applyFilter(stubState.likes, filter);
   return request('/likes/filter', { method: 'POST', body: JSON.stringify(filter) });
 }
 
 export async function filterSavedPosts(filter) {
-  if (useStubApi) return applyFilter(stubState.savedPosts, filter);
   return request('/saved-posts/filter', { method: 'POST', body: JSON.stringify(filter) });
 }
 
 export async function uploadFile(file) {
-  if (useStubApi) return { file_url: '/static/stub-image.jpg' };
   const formData = new FormData();
   formData.append('file', file);
   const response = await fetch(`${API_BASE}/uploads`, { method: 'POST', body: formData });
   if (!response.ok) throw new Error('Upload failed');
   return response.json();
-}
-
-export function isUsingStubApi() {
-  return useStubApi;
 }


### PR DESCRIPTION
## Summary
- remove stub API fallback logic from the shared API utility so calls always hit the real backend
- drop stub-related build arguments and environment variables from Docker configuration
- update smoke test scripts to run without stub API environment flags

## Testing
- npm run lint *(fails due to existing lint issues in built assets and test stubs)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273432de9c832fa4b91ce3c25cb299)