### PR TITLE
Fix dev API base fallback

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -10,7 +10,11 @@ const useStubApi =
   (typeof process !== 'undefined' && process.env.USE_STUB_API === 'true') ||
   (typeof import.meta !== 'undefined' && import.meta.env?.VITE_USE_STUB_API === 'true');
 
-const API_BASE = envBase || ssrBase || '/api';
+const isDev =
+  (typeof import.meta !== 'undefined' && import.meta.env?.DEV) ||
+  (typeof process !== 'undefined' && process.env.NODE_ENV === 'development');
+
+const API_BASE = envBase || ssrBase || (isDev ? 'http://localhost:4000/api' : '/api');
 
 const stubState = {
   user: {


### PR DESCRIPTION
## Summary
- ensure API base falls back to localhost backend during development for out-of-box dev server usage
- retain relative API base for production environments when no override is provided

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692738e15514832fbda43bec6307f11a)