### PR TITLE
Ensure dev default API base targets backend

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -14,7 +14,13 @@ const isDev =
   (typeof import.meta !== 'undefined' && import.meta.env?.DEV) ||
   (typeof process !== 'undefined' && process.env.NODE_ENV === 'development');
 
-const API_BASE = envBase || ssrBase || (isDev ? 'http://localhost:4000/api' : '/api');
+// Vite's dev server doesn't proxy /api to the backend, so keep the localhost
+// default when running locally without an explicit base override.
+const isViteDevServer =
+  typeof window !== 'undefined' && ['5173', '4173'].includes(window.location?.port);
+
+const API_BASE =
+  envBase || ssrBase || (isDev || isViteDevServer ? 'http://localhost:4000/api' : '/api');
 
 const stubState = {
   user: {


### PR DESCRIPTION
## Summary
- ensure Vite dev server defaults to the backend API host when no base is configured
- add dev server port detection to keep production using the relative API base

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692739b672e4832fa95beabf4a71da14)