### PR TITLE
Prevent CLI migrations from seeding database

### DIFF
--- a/backend/database.js
+++ b/backend/database.js
@@ -170,7 +170,10 @@ function filterSavedPosts(filter = {}) {
   return db.prepare(`SELECT * FROM saved_posts ${where}`).all(...params);
 }
 
-initializeDatabase();
+const isCli = require.main === module;
+if (!isCli) {
+  initializeDatabase();
+}
 
 module.exports = {
   db,
@@ -183,7 +186,7 @@ module.exports = {
   filterSavedPosts,
 };
 
-if (require.main === module) {
+if (isCli) {
   const command = process.argv[2];
   if (command === 'migrate') {
     applyScriptsFromDir('migrations', 'schema_migrations');


### PR DESCRIPTION
## Summary
- avoid running migrations and seeds before CLI command selection by checking for CLI usage
- ensure database initialization still occurs when the module is loaded by the application server

## Testing
- node backend/database.js migrate *(fails: missing local better-sqlite3 dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273ba8b928832f870de8bb3352c141)