### PR TITLE
Use Express wildcard for SPA fallback

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -94,7 +94,7 @@ app.post('/api/uploads', upload.single('file'), (req, res) => {
   res.status(201).json({ file_url: fileUrl });
 });
 
-app.get('/{*splat}', (req, res, next) => {
+app.get('*', (req, res, next) => {
   if (
     req.path.startsWith('/api') ||
     req.path.startsWith('/uploads') ||


### PR DESCRIPTION
## Summary
- replace the catch-all route with an Express-compatible wildcard to serve the SPA shell
- maintain exclusions for API, uploads, and asset paths while serving dist/index.html

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273e170630832fae8e742cafb9441c)