### PR TITLE
Use middleware for SPA fallback

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -94,7 +94,7 @@ app.post('/api/uploads', upload.single('file'), (req, res) => {
   res.status(201).json({ file_url: fileUrl });
 });
 
-app.get('/{*splat}', (req, res, next) => {
+app.use((req, res, next) => {
   if (
     req.path.startsWith('/api') ||
     req.path.startsWith('/uploads') ||


### PR DESCRIPTION
## Summary
- replace the SPA catch-all route with a final middleware to avoid Express 5 wildcard issues
- continue excluding API, upload, and asset paths while serving the SPA shell

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273e170630832fae8e742cafb9441c)