### PR TITLE
Improve create post modal behavior and refresh handling

### DIFF
--- a/Components/CreatePostModal.jsx
+++ b/Components/CreatePostModal.jsx
@@ -250,10 +250,20 @@ export default function CreatePostModal({ open, onOpenChange, onPostCreated }) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-4xl max-h-[95vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="text-2xl font-bold text-blue-900 flex items-center">
-            <Camera className="w-6 h-6 mr-2" />
-            Nieuwe foto delen
-          </DialogTitle>
+          <div className="flex items-start justify-between gap-4">
+            <DialogTitle className="text-2xl font-bold text-blue-900 flex items-center">
+              <Camera className="w-6 h-6 mr-2" />
+              Nieuwe foto delen
+            </DialogTitle>
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="text-slate-500 hover:text-slate-800 transition-colors"
+              aria-label="Sluit de modal"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
         </DialogHeader>
         <div className="space-y-6">
           {contentError && (

--- a/Components/ui/dialog.js
+++ b/Components/ui/dialog.js
@@ -1,5 +1,0 @@
-import React from 'react';
-export const Dialog = ({ children }) => React.createElement('div', null, children);
-export const DialogContent = ({ children, className }) => React.createElement('div', { className }, children);
-export const DialogHeader = ({ children }) => React.createElement('div', null, children);
-export const DialogTitle = ({ children, className }) => React.createElement('h3', { className }, children);

--- a/Components/ui/dialog.jsx
+++ b/Components/ui/dialog.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export const Dialog = ({ open, onOpenChange, children }) => {
+  if (!open) return null;
+
+  return ReactDOM.createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm"
+        onClick={() => onOpenChange?.(false)}
+      />
+      <div className="relative z-10 w-full max-w-5xl">{children}</div>
+    </div>,
+    document.body
+  );
+};
+
+export const DialogContent = ({ children, className }) => (
+  <div
+    className={`relative bg-white rounded-2xl shadow-2xl border border-slate-200 max-h-[calc(100vh-4rem)] overflow-y-auto ${className || ''}`}
+  >
+    {children}
+  </div>
+);
+
+export const DialogHeader = ({ children }) => <div className="px-6 pt-6">{children}</div>;
+
+export const DialogTitle = ({ children, className }) => (
+  <h3 className={`text-lg font-semibold text-slate-900 ${className || ''}`}>{children}</h3>
+);

--- a/Layout.jsx
+++ b/Layout.jsx
@@ -44,9 +44,11 @@ export default function Layout({ children, currentPageName }) {
   };
 
   const handlePostCreated = async (newPost) => {
-    await Post.create(newPost);
-    if (location.pathname === PAGE_ROUTES.timeline) {
-      window.location.reload();
+    try {
+      const createdPost = await Post.create(newPost);
+      window.dispatchEvent(new CustomEvent('post:created', { detail: createdPost || newPost }));
+    } catch (error) {
+      console.error('Error creating post:', error);
     }
   };
 
@@ -136,7 +138,7 @@ export default function Layout({ children, currentPageName }) {
           </div>
 
           <button
-            onClick={() => setShowCreatePost(true)}
+            onClick={() => setShowCreatePost((prev) => !prev)}
             className="w-12 h-12 rounded-full shadow-lg bg-gradient-to-br from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 transition-all duration-300 hover:scale-105 active:scale-95 flex items-center justify-center"
           >
             <Plus className="w-6 h-6 text-white" />

--- a/Pages/Timeline.tsx
+++ b/Pages/Timeline.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { Card, CardContent } from '@/components/ui/card';
 import { Post } from '../entities/Post.js';
@@ -14,20 +14,30 @@ export default function Timeline() {
   const [posts, setPosts] = useState<PostSummary[]>([]);
   const [loading, setLoading] = useState(true);
 
+  const loadPosts = useCallback(async () => {
+    try {
+      const recentPosts = await Post.filter({});
+      setPosts(recentPosts || []);
+    } catch (error) {
+      setPosts([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
-    const loadPosts = async () => {
-      try {
-        const recentPosts = await Post.filter({});
-        setPosts(recentPosts || []);
-      } catch (error) {
-        setPosts([]);
-      } finally {
-        setLoading(false);
-      }
+    loadPosts();
+  }, [loadPosts]);
+
+  useEffect(() => {
+    const handlePostCreated = () => {
+      setLoading(true);
+      loadPosts();
     };
 
-    loadPosts();
-  }, []);
+    window.addEventListener('post:created', handlePostCreated);
+    return () => window.removeEventListener('post:created', handlePostCreated);
+  }, [loadPosts]);
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-6 space-y-4">


### PR DESCRIPTION
## Summary
- add portal-based dialog with backdrop and header close control for the create post modal
- keep the floating plus button toggling the modal state and dispatch events instead of reloading after creating posts
- let the timeline listen for create-post events to refresh without navigation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927618c5c7c832f9f2a7818fe9ce97f)