### PR TITLE
Add serene light/dark theme and modern styling

### DIFF
--- a/Components/PostCard.jsx
+++ b/Components/PostCard.jsx
@@ -63,12 +63,12 @@ export default function PostCard({ post, onSaveToMoodboard }) {
   const showImage = image && !imageError;
 
   return (
-    <Card className="bg-gradient-to-b from-indigo-50/70 via-white to-emerald-50/60 dark:from-slate-900 dark:via-slate-950 dark:to-slate-950 border border-indigo-100/60 dark:border-slate-800 shadow-lg overflow-hidden">
-      <div className="relative h-64 sm:h-72 bg-slate-100 dark:bg-slate-800">
+    <Card className="bg-gradient-to-b from-serenity-50/80 via-white to-serenity-100/70 dark:from-midnight-200 dark:via-midnight-300 dark:to-midnight-500 border border-serenity-200/70 dark:border-midnight-50/30 shadow-soft overflow-hidden rounded-2xl">
+      <div className="relative h-64 sm:h-72 bg-serenity-100/60 dark:bg-midnight-100/40">
         {showImage ? (
           <>
             {!imageLoaded && (
-              <div className="absolute inset-0 animate-pulse bg-gradient-to-br from-indigo-100 via-white to-emerald-100 dark:from-slate-800 dark:via-slate-900 dark:to-slate-800" />
+              <div className="absolute inset-0 animate-pulse bg-gradient-to-br from-serenity-100 via-white to-serenity-200 dark:from-midnight-200 dark:via-midnight-300 dark:to-midnight-400" />
             )}
             <img
               src={image}
@@ -79,7 +79,7 @@ export default function PostCard({ post, onSaveToMoodboard }) {
             />
           </>
         ) : (
-          <div className="w-full h-full flex flex-col items-center justify-center text-indigo-700 dark:text-indigo-200 bg-gradient-to-br from-indigo-50 via-white to-emerald-50 dark:from-slate-800 dark:via-slate-900 dark:to-slate-800 space-y-2">
+          <div className="w-full h-full flex flex-col items-center justify-center text-serenity-700 dark:text-serenity-100 bg-gradient-to-br from-serenity-50 via-white to-serenity-100 dark:from-midnight-200 dark:via-midnight-300 dark:to-midnight-500 space-y-2">
             <ImageOff className="w-9 h-9" />
             <p className="text-sm font-medium">Geen afbeelding beschikbaar</p>
           </div>
@@ -90,7 +90,7 @@ export default function PostCard({ post, onSaveToMoodboard }) {
               <Badge
                 key={tag}
                 variant="secondary"
-                className="bg-white/90 text-indigo-700 border border-indigo-100 dark:bg-slate-800/80 dark:text-indigo-100 dark:border-slate-700"
+                className="bg-white/90 text-serenity-700 border border-serenity-200/80 dark:bg-midnight-200/60 dark:text-serenity-50 dark:border-midnight-50/30"
               >
                 {tag}
               </Badge>
@@ -101,11 +101,15 @@ export default function PostCard({ post, onSaveToMoodboard }) {
           <Button
             size="icon"
             variant="secondary"
-            className="rounded-full bg-white/95 text-indigo-700 hover:bg-white dark:bg-slate-900/80 dark:hover:bg-slate-800"
+            className="rounded-full bg-white/95 text-serenity-700 hover:bg-white shadow-soft dark:bg-midnight-200/70 dark:hover:bg-midnight-100/60"
             onClick={handleMoodboard}
             title={saved ? 'Verwijder uit moodboard' : 'Toevoegen aan moodboard'}
           >
-            {saved ? <Bookmark className="w-4 h-4 text-indigo-700" /> : <BookmarkPlus className="w-4 h-4 text-slate-700 dark:text-indigo-100" />}
+            {saved ? (
+              <Bookmark className="w-4 h-4 text-serenity-700" />
+            ) : (
+              <BookmarkPlus className="w-4 h-4 text-midnight-800 dark:text-serenity-100" />
+            )}
           </Button>
         </div>
       </div>
@@ -113,7 +117,9 @@ export default function PostCard({ post, onSaveToMoodboard }) {
       <CardContent className="p-4 sm:p-5 space-y-3">
         <div className="flex items-center justify-between text-xs text-slate-600 dark:text-slate-300">
           <span>{formattedDate}</span>
-          {post?.photographer_name && <span className="font-medium text-indigo-700 dark:text-indigo-200">door {post.photographer_name}</span>}
+          {post?.photographer_name && (
+            <span className="font-semibold text-serenity-700 dark:text-serenity-100">door {post.photographer_name}</span>
+          )}
         </div>
         <div className="space-y-1">
           <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-50">{post?.title || 'Nieuwe post'}</h2>
@@ -126,7 +132,7 @@ export default function PostCard({ post, onSaveToMoodboard }) {
               <Badge
                 key={tag}
                 variant="outline"
-                className="border-indigo-200 text-indigo-800 dark:border-slate-700 dark:text-indigo-100"
+                className="border-serenity-300 text-serenity-800 dark:border-midnight-50/50 dark:text-serenity-50"
               >
                 {tag}
               </Badge>
@@ -139,7 +145,11 @@ export default function PostCard({ post, onSaveToMoodboard }) {
             <Button
               variant={liked ? 'default' : 'ghost'}
               size="sm"
-              className={`flex items-center gap-2 ${liked ? 'bg-indigo-600 text-white hover:bg-indigo-600/90' : 'text-indigo-700 dark:text-indigo-200'}`}
+              className={`flex items-center gap-2 rounded-full shadow-soft ${
+                liked
+                  ? 'bg-serenity-600 text-white hover:bg-serenity-600/90'
+                  : 'text-serenity-700 dark:text-serenity-100 hover:bg-serenity-100/60 dark:hover:bg-midnight-100/40'
+              }`}
               onClick={handleLike}
             >
               <Heart className={`w-4 h-4 ${liked ? 'fill-white' : ''}`} />
@@ -154,7 +164,7 @@ export default function PostCard({ post, onSaveToMoodboard }) {
           <Button
             variant="outline"
             size="sm"
-            className="border-indigo-200 text-indigo-800 hover:bg-indigo-50 dark:border-slate-700 dark:text-indigo-100 dark:hover:bg-slate-800"
+            className="border-serenity-300 text-serenity-800 hover:bg-serenity-100/70 rounded-full shadow-soft dark:border-midnight-50/50 dark:text-serenity-50 dark:hover:bg-midnight-100/40"
             onClick={handleMoodboard}
           >
             {saved ? 'Opgeslagen in moodboard' : 'Bewaar in moodboard'}

--- a/Layout.jsx
+++ b/Layout.jsx
@@ -2,15 +2,26 @@ import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { PAGE_ROUTES } from '@/utils';
 import { User } from './entities/User.js';
-import { Search, UserIcon, LayoutGrid, MessageSquare, Plus, Users } from 'lucide-react';
+import {
+  Search,
+  UserIcon,
+  LayoutGrid,
+  MessageSquare,
+  Plus,
+  Users,
+  SunMedium,
+  Moon,
+} from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import CreatePostModal from '@/components/CreatePostModal';
 import HouseRulesModal from '@/components/HouseRulesModal';
 import { Post } from './entities/Post.js';
+import { useTheme } from '@/context/ThemeContext';
 
 export default function Layout({ children, currentPageName }) {
   const location = useLocation();
+  const { theme, toggleTheme } = useTheme();
   const [user, setUser] = useState(null);
   const [showCreatePost, setShowCreatePost] = useState(false);
   const [showHouseRules, setShowHouseRules] = useState(false);
@@ -62,38 +73,50 @@ export default function Layout({ children, currentPageName }) {
     'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=320&q=80';
 
   return (
-    <div className="min-h-screen font-sans relative">
-      <div
-        className="fixed inset-0 w-full h-screen pointer-events-none z-0"
-        style={{
-          background: 'linear-gradient(to bottom, #E3F2FD 0%, #F8F9FA 50%, #FFFFFF 100%)',
-        }}
-      />
+    <div className="min-h-screen font-sans relative text-slate-900 dark:text-slate-100">
+      <div className="fixed inset-0 w-full h-screen pointer-events-none z-0">
+        <div className="absolute inset-0 bg-gradient-to-br from-serenity-100 via-white to-serenity-50 dark:from-midnight-500 dark:via-midnight-400 dark:to-midnight-600" />
+        <div className="absolute inset-0 opacity-50 bg-[radial-gradient(circle_at_20%_20%,rgba(70,99,172,0.18),transparent_25%),radial-gradient(circle_at_80%_0%,rgba(161,185,226,0.2),transparent_20%),radial-gradient(circle_at_50%_80%,rgba(70,99,172,0.12),transparent_30%)]" />
+      </div>
 
-      {currentPageName === 'Timeline' && (
-        <header className="sticky top-0 z-40 bg-white/80 backdrop-blur-md border-b border-slate-200/50">
-          <div className="max-w-xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex justify-between items-center h-16">
-              <Link to={PAGE_ROUTES.timeline} className="flex items-center gap-2">
-                <img
-                  src="https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/68d3a37e32ef31e2813744f9/017b1b42f_Exhibitlogohorizontaal1.png"
-                  alt="Exhibit"
-                  className="h-8 w-auto"
-                />
-              </Link>
+      <header className="sticky top-0 z-40 backdrop-blur-xl bg-white/80 dark:bg-midnight-100/60 border-b border-serenity-200/60 dark:border-midnight-50/30 shadow-soft">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16 gap-3">
+            <Link to={PAGE_ROUTES.timeline} className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-2xl bg-gradient-to-br from-serenity-500 to-serenity-600 text-white flex items-center justify-center shadow-floating">
+                <LayoutGrid className="w-5 h-5" />
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-[0.2em] text-serenity-600 dark:text-serenity-200">Exhibit</p>
+                <p className="font-semibold text-lg text-midnight-900 dark:text-white">Creatieve community</p>
+              </div>
+            </Link>
+
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={toggleTheme}
+                className="inline-flex items-center gap-2 rounded-full px-3 py-2 bg-serenity-100 dark:bg-midnight-50/20 border border-serenity-200/70 dark:border-midnight-50/30 text-midnight-900 dark:text-white shadow-soft hover:-translate-y-[1px] transition"
+                aria-label="Schakel thema"
+              >
+                {theme === 'light' ? <SunMedium className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+                <span className="hidden sm:inline text-sm font-semibold">{theme === 'light' ? 'Licht' : 'Donker'}</span>
+              </button>
               <Link to={PAGE_ROUTES.chat}>
-                <Button variant="ghost" size="icon" className="bg-white/50 shadow-md rounded-full">
-                  <MessageSquare className="w-5 h-5 text-slate-700" />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="bg-serenity-500 text-white hover:bg-serenity-600 rounded-full shadow-floating h-10 w-10"
+                >
+                  <MessageSquare className="w-5 h-5" />
                 </Button>
               </Link>
             </div>
           </div>
-        </header>
-      )}
+        </div>
+      </header>
 
-      <main className={`pb-32 ${currentPageName === 'Timeline' ? 'pt-0' : 'pt-4'} relative z-10`}>
-        {children}
-      </main>
+      <main className={`pb-32 ${currentPageName === 'Timeline' ? 'pt-4' : 'pt-8'} relative z-10`}>{children}</main>
 
       <HouseRulesModal open={showHouseRules} onOpenChange={handleCloseRules} />
       <CreatePostModal
@@ -108,7 +131,7 @@ export default function Layout({ children, currentPageName }) {
       >
         <div className="relative flex items-end justify-center gap-3">
           <div className="pointer-events-auto flex items-end justify-center gap-3">
-            <div className="flex items-center justify-between gap-1 rounded-full border border-slate-200/90 bg-white/95 px-2.5 py-1.5 shadow-[0_12px_28px_rgba(15,23,42,0.18)] backdrop-blur supports-[backdrop-filter]:bg-white/80">
+            <div className="flex items-center justify-between gap-1 rounded-full border border-serenity-200/80 dark:border-midnight-50/30 bg-white/90 dark:bg-midnight-100/70 px-2.5 py-1.5 shadow-floating backdrop-blur supports-[backdrop-filter]:bg-white/80">
               {tabItems.map((item) => {
                 const isRootPath = item.path === PAGE_ROUTES.timeline;
                 const isActive =
@@ -121,16 +144,18 @@ export default function Layout({ children, currentPageName }) {
                   <Link
                     key={`${item.name}-${item.path}`}
                     to={item.path}
-                    className={`group flex items-center justify-center gap-2 rounded-full px-3 py-2 text-sm font-medium transition-all duration-200 ${
+                    className={`group flex items-center justify-center gap-2 rounded-full px-3 py-2 text-sm font-semibold transition-all duration-200 ${
                       isActive
-                        ? 'bg-blue-600 text-white shadow-lg shadow-blue-300/40'
-                        : 'text-slate-700 hover:bg-slate-50 hover:text-blue-600'
+                        ? 'bg-serenity-600 text-white shadow-floating'
+                        : 'text-midnight-800 dark:text-slate-200 hover:bg-serenity-100/90 dark:hover:bg-midnight-50/30'
                     }`}
                   >
                     {item.isProfile ? (
                       <div
                         className={`p-0.5 rounded-full border transition-colors ${
-                          isActive ? 'border-white/70 bg-white/10' : 'border-blue-50 group-hover:border-blue-200'
+                          isActive
+                            ? 'border-white/70 bg-white/10'
+                            : 'border-serenity-100 dark:border-midnight-50/40 group-hover:border-serenity-200'
                         }`}
                       >
                         <Avatar className="w-9 h-9 border border-white/60 shadow-sm">
@@ -143,8 +168,8 @@ export default function Layout({ children, currentPageName }) {
                     ) : (
                       <IconComponent
                         className={`w-5 h-5 transition-transform duration-200 ${
-                            isActive ? 'scale-110' : 'group-hover:scale-105'
-                          }`}
+                          isActive ? 'scale-110' : 'group-hover:scale-105'
+                        }`}
                       />
                     )}
                     <span>{item.name}</span>
@@ -158,7 +183,7 @@ export default function Layout({ children, currentPageName }) {
                 type="button"
                 onClick={actionItem.action}
                 aria-label={actionItem.name}
-                className="pointer-events-auto flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 text-white shadow-[0_14px_35px_rgba(59,130,246,0.35)] transition-transform duration-200 hover:scale-105 focus:scale-105 focus:outline-none focus:ring-4 focus:ring-blue-200"
+                className="pointer-events-auto flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-serenity-500 to-serenity-700 text-white shadow-floating transition-transform duration-200 hover:scale-105 focus:scale-105 focus:outline-none focus:ring-4 focus:ring-serenity-200"
               >
                 {ActionIcon && <ActionIcon className="h-6 w-6" />}
               </button>

--- a/Pages/Community.jsx
+++ b/Pages/Community.jsx
@@ -45,17 +45,17 @@ export default function Community() {
   };
 
   return (
-    <div className="max-w-6xl mx-auto px-4 py-2">
+    <div className="max-w-6xl mx-auto px-4 py-2 space-y-6">
       {loading ? (
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
           {Array(6).fill(0).map((_, i) => (
-            <Card key={i} className="animate-pulse">
+            <Card key={i} className="animate-pulse glass-panel">
               <CardHeader>
-                <div className="bg-slate-200 h-6 rounded mb-2"></div>
-                <div className="bg-slate-200 h-4 rounded w-2/3"></div>
+                <div className="bg-serenity-100 h-6 rounded mb-2"></div>
+                <div className="bg-serenity-100 h-4 rounded w-2/3"></div>
               </CardHeader>
               <CardContent>
-                <div className="bg-slate-200 h-16 rounded"></div>
+                <div className="bg-serenity-100 h-16 rounded"></div>
               </CardContent>
             </Card>
           ))}
@@ -64,19 +64,23 @@ export default function Community() {
         <div className="text-center py-16">
           {error ? (
             <>
-              <Users className="w-16 h-16 mx-auto mb-4 text-red-200" />
-              <h3 className="text-lg font-medium text-slate-900 mb-2">Er ging iets mis</h3>
-              <p className="text-slate-600 mb-4">{error}</p>
-              <Button variant="outline" onClick={loadCommunities} className="inline-flex items-center gap-2">
+              <Users className="w-16 h-16 mx-auto mb-4 text-serenity-400" />
+              <h3 className="text-lg font-medium text-midnight-900 dark:text-white mb-2">Er ging iets mis</h3>
+              <p className="text-slate-600 dark:text-slate-200 mb-4">{error}</p>
+              <Button
+                variant="outline"
+                onClick={loadCommunities}
+                className="inline-flex items-center gap-2 rounded-full border-serenity-300 text-serenity-800 hover:bg-serenity-100/70 shadow-soft"
+              >
                 <RefreshCcw className="w-4 h-4" />
                 Opnieuw proberen
               </Button>
             </>
           ) : (
             <>
-              <Users className="w-16 h-16 mx-auto mb-4 text-slate-300" />
-              <h3 className="text-lg font-medium text-slate-900 mb-2">Communities komen binnenkort</h3>
-              <p className="text-slate-600">We werken hard aan het opzetten van inspirerende community spaces</p>
+              <Users className="w-16 h-16 mx-auto mb-4 text-serenity-400" />
+              <h3 className="text-lg font-medium text-midnight-900 dark:text-white mb-2">Communities komen binnenkort</h3>
+              <p className="text-slate-600 dark:text-slate-200">We werken hard aan het opzetten van inspirerende community spaces</p>
             </>
           )}
         </div>
@@ -93,7 +97,7 @@ export default function Community() {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: index * 0.1 }}
               >
-                <Card className="hover:shadow-lg transition-all duration-300 border-slate-200 h-full bg-white/80 backdrop-blur-sm">
+                <Card className="hover:shadow-floating transition-all duration-300 glass-panel h-full">
                   <CardHeader>
                     <div className="flex items-start justify-between">
                       <div className="flex items-center space-x-3">
@@ -101,7 +105,7 @@ export default function Community() {
                           <IconComponent className="w-5 h-5" />
                         </div>
                         <div>
-                          <CardTitle className="text-lg text-slate-900">{community.name}</CardTitle>
+                          <CardTitle className="text-lg text-midnight-900 dark:text-white">{community.name}</CardTitle>
                           <Badge variant="outline" className={`mt-1 ${colorClass} border text-xs`}>
                             {community.member_count} leden
                           </Badge>
@@ -110,10 +114,10 @@ export default function Community() {
                     </div>
                   </CardHeader>
                   <CardContent className="pt-0">
-                    <p className="text-slate-600 text-sm leading-relaxed mb-4">
+                    <p className="text-slate-700 dark:text-slate-200 text-sm leading-relaxed mb-4">
                       {community.description}
                     </p>
-                    <Button variant="outline" className="w-full">
+                    <Button variant="outline" className="w-full rounded-full border-serenity-300 text-serenity-800 hover:bg-serenity-100/70 shadow-soft">
                       Bekijk community
                     </Button>
                   </CardContent>

--- a/Pages/Discover.jsx
+++ b/Pages/Discover.jsx
@@ -100,11 +100,15 @@ const PeopleTab = ({ searchTerm }) => {
       {/* Role Filter Pills */}
       <div className="flex space-x-2 mb-6 overflow-x-auto pb-2">
         {userRoles.map(role => (
-          <Button 
-            key={role.id} 
-            variant={activeRole === role.id ? 'default' : 'outline'} 
-            onClick={() => setActiveRole(role.id)} 
-            className="shrink-0 bg-white/80"
+          <Button
+            key={role.id}
+            variant={activeRole === role.id ? 'default' : 'outline'}
+            onClick={() => setActiveRole(role.id)}
+            className={`shrink-0 ${
+              activeRole === role.id
+                ? 'bg-serenity-600 text-white shadow-soft'
+                : 'bg-white/80 text-midnight-900 dark:text-serenity-50 border-serenity-200/70'
+            } rounded-full px-4 py-2`}
           >
             {role.label}
           </Button>
@@ -118,7 +122,7 @@ const PeopleTab = ({ searchTerm }) => {
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
           {filteredUsers.map(user => (
             <motion.div key={user.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-              <Card className="text-center shadow-lg bg-white/70 backdrop-blur-sm rounded-2xl overflow-hidden hover:shadow-xl transition-all">
+              <Card className="text-center glass-panel overflow-hidden hover:shadow-floating transition-all">
                 <Avatar className="w-full h-32 sm:h-40 rounded-none">
                   <AvatarImage src={user.avatar_url} className="object-cover" />
                   <AvatarFallback className="rounded-none">
@@ -126,8 +130,8 @@ const PeopleTab = ({ searchTerm }) => {
                   </AvatarFallback>
                 </Avatar>
                 <CardContent className="p-3">
-                  <h4 className="font-semibold truncate text-slate-800">{user.display_name || "Gebruiker"}</h4>
-                  <p className="text-xs text-slate-500 truncate">{user.roles?.join(', ') || "Creatief"}</p>
+                  <h4 className="font-semibold truncate text-midnight-900 dark:text-white">{user.display_name || "Gebruiker"}</h4>
+                  <p className="text-xs text-slate-600 dark:text-slate-200 truncate">{user.roles?.join(', ') || "Creatief"}</p>
                 </CardContent>
               </Card>
             </motion.div>
@@ -180,29 +184,37 @@ const StylesTab = ({ searchTerm }) => {
     <div className="px-4">
       {/* Style Filter Pills */}
       <div className="flex flex-wrap gap-3 mb-6">
-        <Button 
-          variant={!selectedStyle ? 'default' : 'outline'} 
+        <Button
+          variant={!selectedStyle ? 'default' : 'outline'}
           onClick={() => setSelectedStyle(null)}
-          className="bg-white/80"
+          className={`rounded-full px-4 py-2 ${
+            !selectedStyle
+              ? 'bg-serenity-600 text-white shadow-soft'
+              : 'bg-white/80 text-midnight-900 dark:text-serenity-50 border-serenity-200/70'
+          }`}
         >
           Alles
         </Button>
         {visibleStyles.map(style => (
-          <Button 
-            key={style.id} 
-            variant={selectedStyle === style.id ? 'default' : 'outline'} 
+          <Button
+            key={style.id}
+            variant={selectedStyle === style.id ? 'default' : 'outline'}
             onClick={() => setSelectedStyle(style.id)}
-            className="bg-white/80"
+            className={`rounded-full px-4 py-2 ${
+              selectedStyle === style.id
+                ? 'bg-serenity-600 text-white shadow-soft'
+                : 'bg-white/80 text-midnight-900 dark:text-serenity-50 border-serenity-200/70'
+            }`}
           >
             <span className="mr-1">{style.icon}</span>
             {style.label}
           </Button>
         ))}
         {!showAllStyles && photographyStyles.length > 5 && (
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             onClick={() => setShowAllStyles(true)}
-            className="bg-white/80 text-blue-600 border-blue-300"
+            className="rounded-full bg-white/80 text-serenity-700 border-serenity-300 hover:bg-serenity-100 shadow-soft"
           >
             Toon meer...
           </Button>
@@ -227,26 +239,30 @@ export default function Discover() {
   const [searchTerm, setSearchTerm] = useState("");
 
   return (
-    <div className="max-w-6xl mx-auto px-2 pt-2">
+    <div className="max-w-6xl mx-auto px-3 pt-4 space-y-6">
       {/* Search Bar - direct starten */}
-      <div className="relative mb-6 px-4">
-        <Search className="absolute left-7 top-1/2 transform -translate-y-1/2 text-slate-400 w-5 h-5" />
-        <Input
-          placeholder="Zoek naar mensen, stijlen, of titels..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          className="pl-12 py-3 text-lg bg-white/70 backdrop-blur-md rounded-full shadow-lg border-slate-200/50"
-        />
+      <div className="relative px-4">
+        <div className="glass-panel rounded-2xl shadow-floating p-1">
+          <div className="relative">
+            <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-serenity-500 dark:text-serenity-200 w-5 h-5" />
+            <Input
+              placeholder="Zoek naar mensen, stijlen, of titels..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="pl-11 pr-4 py-3 text-lg bg-transparent border-none focus-visible:ring-0"
+            />
+          </div>
+        </div>
       </div>
 
       {/* Tabs */}
       <Tabs defaultValue="people" className="w-full">
-        <TabsList className="grid w-full grid-cols-2 mb-6 bg-white/50 backdrop-blur-sm rounded-xl mx-4">
-          <TabsTrigger value="people" className="flex items-center space-x-2">
+        <TabsList className="grid w-full grid-cols-2 mb-6 bg-white/70 dark:bg-midnight-100/60 backdrop-blur-sm rounded-2xl mx-4 border border-serenity-200/70 dark:border-midnight-50/30 shadow-soft">
+          <TabsTrigger value="people" className="flex items-center space-x-2 data-[state=active]:bg-serenity-600 data-[state=active]:text-white rounded-xl">
             <UserIcon className="w-4 h-4" />
             <span>Mensen</span>
           </TabsTrigger>
-          <TabsTrigger value="styles" className="flex items-center space-x-2">
+          <TabsTrigger value="styles" className="flex items-center space-x-2 data-[state=active]:bg-serenity-600 data-[state=active]:text-white rounded-xl">
             <Palette className="w-4 h-4" />
             <span>Stijlen</span>
           </TabsTrigger>

--- a/Pages/Profile.jsx
+++ b/Pages/Profile.jsx
@@ -264,11 +264,11 @@ export default function Profile() {
     return (
       <div className="max-w-4xl mx-auto px-4">
         <div className="animate-pulse space-y-8">
-          <div className="bg-white/50 h-40 rounded-2xl shadow-lg"></div>
-          <div className="bg-white/50 h-12 rounded-2xl shadow-lg"></div>
+          <div className="bg-serenity-100/70 h-40 rounded-2xl shadow-soft"></div>
+          <div className="bg-serenity-100/70 h-12 rounded-2xl shadow-soft"></div>
           <div className="grid grid-cols-3 gap-4">
             {Array(6).fill(0).map((_, i) => (
-              <div key={i} className="bg-white/50 aspect-square rounded-2xl shadow-lg"></div>
+              <div key={i} className="bg-serenity-100/70 aspect-square rounded-2xl shadow-soft"></div>
             ))}
           </div>
         </div>
@@ -279,12 +279,12 @@ export default function Profile() {
   if (!user) return null;
 
   return (
-    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-2">
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-2 space-y-6">
       <HouseRulesModal open={showHouseRules} onOpenChange={setShowHouseRules} />
       <EditProfileDialog open={showEditProfile} onOpenChange={setShowEditProfile} user={user} onProfileUpdate={handleProfileUpdate} />
 
       {/* Profile Header */}
-      <Card className="mb-8 bg-white/60 backdrop-blur-md border-slate-200/50 shadow-xl rounded-2xl">
+      <Card className="glass-panel shadow-floating">
         <CardContent className="p-6">
           <div className="flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-6">
             <Avatar className="w-24 h-24 ring-4 ring-white shadow-lg">
@@ -292,16 +292,16 @@ export default function Profile() {
               <AvatarFallback>{user.display_name?.[0]}</AvatarFallback>
             </Avatar>
             <div className="flex-1 text-center md:text-left">
-              <h1 className="text-3xl font-bold text-slate-900">{user.display_name || user.full_name}</h1>
-              <p className="text-slate-600 mt-2">{user.bio || "Deel je verhaal en inspireer anderen..."}</p>
-               <div className="flex flex-wrap gap-2 mt-4 justify-center md:justify-start">
+              <h1 className="text-3xl font-bold text-midnight-900 dark:text-white">{user.display_name || user.full_name}</h1>
+              <p className="text-slate-700 dark:text-slate-200 mt-2">{user.bio || "Deel je verhaal en inspireer anderen..."}</p>
+              <div className="flex flex-wrap gap-2 mt-4 justify-center md:justify-start">
                 {user.roles?.map(roleId => {
                     const roleInfo = userRoles.find(r => r.id === roleId);
-                    return <Badge key={roleId} variant="secondary">{roleInfo?.label}</Badge>
+                    return <Badge key={roleId} variant="secondary" className="bg-serenity-100 text-serenity-800 border-serenity-200">{roleInfo?.label}</Badge>
                 })}
                 {user.styles?.slice(0, 3).map(styleId => {
                     const styleInfo = photographyStyles.find(s => s.id === styleId);
-                    return <Badge key={styleId} variant="outline">{styleInfo?.label}</Badge>
+                    return <Badge key={styleId} variant="outline" className="border-serenity-300 text-serenity-800 dark:text-serenity-100">{styleInfo?.label}</Badge>
                 })}
               </div>
             </div>
@@ -310,57 +310,57 @@ export default function Profile() {
       </Card>
 
       {/* Stats and Settings */}
-      <Card className="mb-8 bg-white/60 backdrop-blur-md border-slate-200/50 shadow-xl rounded-2xl">
+      <Card className="glass-panel shadow-floating">
         <CardContent className="p-4 flex justify-around items-center flex-wrap gap-4">
             <div className="text-center">
-              <div className="text-2xl font-bold text-slate-900">{userPosts.length}</div>
-              <div className="text-sm text-slate-600 uppercase">Posts</div>
+              <div className="text-2xl font-bold text-midnight-900 dark:text-white">{userPosts.length}</div>
+              <div className="text-sm text-slate-600 dark:text-slate-300 uppercase">Posts</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-slate-900">{savedPosts.length}</div>
-              <div className="text-sm text-slate-600 uppercase">Opgeslagen</div>
+              <div className="text-2xl font-bold text-midnight-900 dark:text-white">{savedPosts.length}</div>
+              <div className="text-sm text-slate-600 dark:text-slate-300 uppercase">Opgeslagen</div>
             </div>
             <div className="flex items-center space-x-2">
-                <Button variant="ghost" size="icon" onClick={() => setShowEditProfile(true)} title="Profiel bewerken"><Edit className="w-5 h-5" /></Button>
+                <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" onClick={() => setShowEditProfile(true)} title="Profiel bewerken"><Edit className="w-5 h-5" /></Button>
                 <Link to={createPageUrl("Analytics")}>
-                  <Button variant="ghost" size="icon" title="Statistieken"><BarChart2 className="w-5 h-5" /></Button>
+                  <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" title="Statistieken"><BarChart2 className="w-5 h-5" /></Button>
                 </Link>
-                <Button variant="ghost" size="icon" onClick={toggleSensitiveContent} title={user.show_sensitive_content ? "Gevoelige content verbergen" : "Gevoelige content tonen"}>
+                <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" onClick={toggleSensitiveContent} title={user.show_sensitive_content ? "Gevoelige content verbergen" : "Gevoelige content tonen"}>
                   {user.show_sensitive_content ? <Eye className="w-5 h-5" /> : <EyeOff className="w-5 h-5" />}
                 </Button>
-                <Button variant="ghost" size="icon" onClick={() => setShowHouseRules(true)} title="Huisregels"><Shield className="w-5 h-5" /></Button>
-                <Button variant="ghost" size="icon" onClick={handleLogout} title="Uitloggen"><LogOut className="w-5 h-5 text-red-500" /></Button>
+                <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" onClick={() => setShowHouseRules(true)} title="Huisregels"><Shield className="w-5 h-5" /></Button>
+                <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" onClick={handleLogout} title="Uitloggen"><LogOut className="w-5 h-5 text-red-500" /></Button>
             </div>
         </CardContent>
       </Card>
       
       {/* Content Tabs */}
-      <Tabs defaultValue="posts" className="w-full">
-        <TabsList className="grid w-full grid-cols-2 mb-6 bg-white/50 backdrop-blur-sm rounded-xl">
-          <TabsTrigger value="posts" className="flex items-center space-x-2"><Grid className="w-4 h-4" /><span>Mijn Posts</span></TabsTrigger>
-          <TabsTrigger value="saved" className="flex items-center space-x-2"><Bookmark className="w-4 h-4" /><span>Moodboard</span></TabsTrigger>
-        </TabsList>
+        <Tabs defaultValue="posts" className="w-full">
+          <TabsList className="grid w-full grid-cols-2 mb-6 bg-white/70 dark:bg-midnight-100/60 backdrop-blur-sm rounded-2xl border border-serenity-200/70 dark:border-midnight-50/30 shadow-soft">
+            <TabsTrigger value="posts" className="flex items-center space-x-2 data-[state=active]:bg-serenity-600 data-[state=active]:text-white rounded-xl"><Grid className="w-4 h-4" /><span>Mijn Posts</span></TabsTrigger>
+            <TabsTrigger value="saved" className="flex items-center space-x-2 data-[state=active]:bg-serenity-600 data-[state=active]:text-white rounded-xl"><Bookmark className="w-4 h-4" /><span>Moodboard</span></TabsTrigger>
+          </TabsList>
 
         <TabsContent value="posts">
-          {userPosts.length === 0 ? (
-            <div className="text-center py-16 bg-white/60 backdrop-blur-md rounded-2xl border border-slate-200/50 shadow-lg">
-              <Camera className="w-16 h-16 mx-auto mb-4 text-slate-300" />
-              <h3 className="text-lg font-medium text-slate-900 mb-2">Nog geen posts gedeeld</h3>
-              <p className="text-slate-600">Begin met het delen van je werk om je portfolio op te bouwen</p>
-            </div>
-          ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-              {userPosts.map((post, index) => (
-                <motion.div
-                  key={post.id}
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ delay: index * 0.05 }}
-                  className="aspect-square relative rounded-xl overflow-hidden group cursor-pointer shadow-lg"
-                >
-                  <img src={post.image_url} alt={post.title} className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105" />
-                  <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-all duration-300 flex items-end p-4">
-                    <h4 className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300">{post.title}</h4>
+            {userPosts.length === 0 ? (
+              <div className="text-center py-16 glass-panel shadow-floating">
+                <Camera className="w-16 h-16 mx-auto mb-4 text-serenity-500" />
+                <h3 className="text-lg font-medium text-midnight-900 dark:text-white mb-2">Nog geen posts gedeeld</h3>
+                <p className="text-slate-700 dark:text-slate-200">Begin met het delen van je werk om je portfolio op te bouwen</p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+                {userPosts.map((post, index) => (
+                  <motion.div
+                    key={post.id}
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ delay: index * 0.05 }}
+                    className="aspect-square relative rounded-xl overflow-hidden group cursor-pointer shadow-soft"
+                  >
+                    <img src={post.image_url} alt={post.title} className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105" />
+                    <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-all duration-300 flex items-end p-4">
+                      <h4 className="text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-300">{post.title}</h4>
                   </div>
                 </motion.div>
               ))}
@@ -369,25 +369,25 @@ export default function Profile() {
         </TabsContent>
 
         <TabsContent value="saved">
-          {savedPosts.length === 0 ? (
-            <div className="text-center py-16 bg-white/60 backdrop-blur-md rounded-2xl border border-slate-200/50 shadow-lg">
-              <Bookmark className="w-16 h-16 mx-auto mb-4 text-slate-300" />
-              <h3 className="text-lg font-medium text-slate-900 mb-2">Nog geen foto's opgeslagen</h3>
-              <p className="text-slate-600">Sla inspirerende foto's op om je persoonlijke moodboard te maken</p>
-            </div>
-          ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-              {savedPosts.map((post, index) => (
-                <motion.div
-                  key={post.id}
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ delay: index * 0.05 }}
-                  className="aspect-square relative rounded-xl overflow-hidden group cursor-pointer shadow-lg"
-                >
-                  <img src={post.image_url} alt={post.title} className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105" />
-                  <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-all duration-300 flex items-end p-4">
-                    <div className="text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+            {savedPosts.length === 0 ? (
+              <div className="text-center py-16 glass-panel shadow-floating">
+                <Bookmark className="w-16 h-16 mx-auto mb-4 text-serenity-500" />
+                <h3 className="text-lg font-medium text-midnight-900 dark:text-white mb-2">Nog geen foto's opgeslagen</h3>
+                <p className="text-slate-700 dark:text-slate-200">Sla inspirerende foto's op om je persoonlijke moodboard te maken</p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+                {savedPosts.map((post, index) => (
+                  <motion.div
+                    key={post.id}
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ delay: index * 0.05 }}
+                    className="aspect-square relative rounded-xl overflow-hidden group cursor-pointer shadow-soft"
+                  >
+                    <img src={post.image_url} alt={post.title} className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105" />
+                    <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-all duration-300 flex items-end p-4">
+                      <div className="text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                         <h4 className="font-medium">{post.title}</h4>
                         <p className="text-sm opacity-80">door {post.photographer_name}</p>
                     </div>

--- a/Pages/Timeline.tsx
+++ b/Pages/Timeline.tsx
@@ -53,11 +53,15 @@ export default function Timeline() {
   }, [loadPosts]);
 
   return (
-    <div className="max-w-2xl mx-auto px-4 py-6 space-y-4">
-      <div className="space-y-2">
-        <p className="text-xs uppercase tracking-wide text-blue-600 font-semibold">Exhibit</p>
-        <h1 className="text-2xl sm:text-3xl font-bold text-slate-900">Tijdlijn</h1>
-        <p className="text-slate-600">De nieuwste creaties uit de community op een rij.</p>
+    <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
+      <div className="space-y-3 glass-panel p-5">
+        <p className="text-xs uppercase tracking-[0.2em] text-serenity-600 font-semibold">Exhibit</p>
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold text-midnight-900 dark:text-white">Tijdlijn</h1>
+            <p className="text-slate-700 dark:text-slate-200">De nieuwste creaties uit de community op een rij.</p>
+          </div>
+        </div>
       </div>
 
       {loading ? (
@@ -67,9 +71,9 @@ export default function Timeline() {
           ))}
         </div>
       ) : posts.length === 0 ? (
-        <div className="bg-white/80 backdrop-blur-sm border border-slate-200 shadow-sm rounded-2xl p-6 text-center space-y-2">
-          <p className="text-lg font-semibold text-slate-900">Nog geen posts</p>
-          <p className="text-slate-600">Plaats een nieuw werk om de tijdlijn te vullen.</p>
+        <div className="glass-panel p-6 text-center space-y-2">
+          <p className="text-lg font-semibold text-midnight-900 dark:text-white">Nog geen posts</p>
+          <p className="text-slate-600 dark:text-slate-200">Plaats een nieuw werk om de tijdlijn te vullen.</p>
         </div>
       ) : (
         <div className="space-y-6">

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'exhibit-theme';
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('light');
+
+  useEffect(() => {
+    const savedTheme = (localStorage.getItem(STORAGE_KEY) as Theme | null) ?? undefined;
+    if (savedTheme) {
+      setThemeState(savedTheme);
+      return;
+    }
+
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    setThemeState(prefersDark ? 'dark' : 'light');
+  }, []);
+
+  const applyTheme = useCallback((nextTheme: Theme) => {
+    const root = document.documentElement;
+    if (nextTheme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, []);
+
+  useEffect(() => {
+    applyTheme(theme);
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [applyTheme, theme]);
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((prev) => (prev === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme,
+      setTheme,
+    }),
+    [theme, toggleTheme, setTheme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,3 +2,48 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: light;
+  }
+
+  .dark {
+    color-scheme: dark;
+  }
+
+  body {
+    @apply min-h-screen bg-gradient-to-br from-serenity-50 via-white to-serenity-100 text-slate-900 antialiased transition-colors duration-300;
+  }
+
+  .dark body {
+    @apply bg-gradient-to-br from-midnight-600 via-midnight-500 to-midnight-600 text-slate-100;
+  }
+
+  ::selection {
+    @apply bg-serenity-200 text-midnight-900;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-semibold text-midnight-900 dark:text-white tracking-tight;
+  }
+
+  p {
+    @apply text-slate-700 dark:text-slate-200 leading-relaxed;
+  }
+}
+
+@layer components {
+  .glass-panel {
+    @apply bg-white/70 dark:bg-midnight-100/60 backdrop-blur-lg border border-serenity-200/70 dark:border-midnight-50/30 shadow-soft rounded-2xl;
+  }
+
+  .pill-button {
+    @apply inline-flex items-center gap-2 rounded-full px-4 py-2 font-medium transition-all duration-200 shadow-soft bg-serenity-500 text-white hover:bg-serenity-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-serenity-300 dark:focus-visible:ring-midnight-50/50;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import ProfilePage from '../Pages/Profile.jsx';
 import SearchPage from '../Pages/Discover.jsx';
 import TimelinePage from '../Pages/Timeline';
 import { PAGE_ROUTES } from '@/utils';
+import { ThemeProvider } from '@/context/ThemeContext';
 
 const routerBasename = (() => {
   const baseUrl = import.meta.env.BASE_URL || '/';
@@ -42,15 +43,17 @@ const renderPage = (pageName: string, element: React.ReactNode) => (
 
 function App() {
   return (
-    <BrowserRouter basename={routerBasename}>
-      <Routes>
-        <Route path={PAGE_ROUTES.timeline} element={renderPage('Timeline', <TimelinePage />)} />
-        <Route path={PAGE_ROUTES.community} element={renderPage('Community', <CommunityPage />)} />
-        <Route path={PAGE_ROUTES.discover} element={renderPage('Discover', <SearchPage />)} />
-        <Route path={PAGE_ROUTES.profile} element={renderPage('Profile', <ProfilePage />)} />
-        <Route path={PAGE_ROUTES.analytics} element={renderPage('Analytics', <AnalyticsPage />)} />
-      </Routes>
-    </BrowserRouter>
+    <ThemeProvider>
+      <BrowserRouter basename={routerBasename}>
+        <Routes>
+          <Route path={PAGE_ROUTES.timeline} element={renderPage('Timeline', <TimelinePage />)} />
+          <Route path={PAGE_ROUTES.community} element={renderPage('Community', <CommunityPage />)} />
+          <Route path={PAGE_ROUTES.discover} element={renderPage('Discover', <SearchPage />)} />
+          <Route path={PAGE_ROUTES.profile} element={renderPage('Profile', <ProfilePage />)} />
+          <Route path={PAGE_ROUTES.analytics} element={renderPage('Analytics', <AnalyticsPage />)} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
   );
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/**/*.{js,jsx,ts,tsx}',
@@ -7,7 +8,44 @@ module.exports = {
     './Components/**/*.{js,jsx,ts,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        serenity: {
+          50: '#e1f1fd',
+          100: '#d2deeb',
+          200: '#c8d9ed',
+          300: '#c1d8f0',
+          400: '#9db8e0',
+          500: '#6f92c8',
+          600: '#4663ac',
+          700: '#324c8a',
+          800: '#273c70',
+          900: '#1e315c',
+          950: '#131c35',
+        },
+        midnight: {
+          50: '#1b2436',
+          100: '#172032',
+          200: '#141c2d',
+          300: '#111927',
+          400: '#0f1521',
+          500: '#0c111b',
+          600: '#0a0e17',
+          700: '#080b12',
+          800: '#05070c',
+          900: '#030507',
+          950: '#020304',
+        },
+      },
+      boxShadow: {
+        floating: '0 18px 45px rgba(70, 99, 172, 0.25)',
+        soft: '0 10px 30px rgba(24, 38, 76, 0.15)',
+      },
+      borderRadius: {
+        xl: '1.25rem',
+        '2xl': '1.5rem',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add serene light/dark color palette and global surface styles
- introduce theme context/provider with toggle and refreshed navigation chrome
- update core pages and cards with rounded glass panels and consistent spacing

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928852bbe6c832f870a79cd1e1bd1dc)