### PR TITLE
Ensure seeded posts use reachable image URLs

### DIFF
--- a/backend/seeds/001_seed.sql
+++ b/backend/seeds/001_seed.sql
@@ -2,26 +2,51 @@ INSERT INTO users (email, display_name, avatar_url, bio, roles, instagram)
 VALUES (
   'user@example.com',
   'Demo User',
-  '',
+  'https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=200&q=80',
   'Fotograaf & model',
   '["model"]',
   '@demo'
 );
 
 INSERT INTO posts (id, title, caption, image_url, photography_style, tags, trigger_warnings, created_by)
-VALUES (
-  'seed-1',
-  'Zonsopgang',
-  'Een serene ochtendshoot',
-  '/uploads/sample-1.jpg',
-  'portrait',
-  '["portrait"]',
-  '[]',
-  'user@example.com'
-);
+VALUES
+  (
+    'seed-1',
+    'Zonsopgang',
+    'Een serene ochtendshoot',
+    'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1400&q=80',
+    'portrait',
+    '["portrait"]',
+    '[]',
+    'user@example.com'
+  ),
+  (
+    'seed-2',
+    'Studio Shapes',
+    'Grafische fashion-shoot met harde schaduwen en kleuraccenten.',
+    'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=1400&q=80',
+    'fashion',
+    '["fashion","editorial"]',
+    '[]',
+    'user@example.com'
+  ),
+  (
+    'seed-3',
+    'Analog Afternoon',
+    'Candid momenten geschoten op 35mm film.',
+    'https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?auto=format&fit=crop&w=1400&q=80',
+    'candid',
+    '["candid","travel"]',
+    '[]',
+    'user@example.com'
+  );
 
 INSERT INTO likes (id, post_id, user_email)
-VALUES ('like-1', 'seed-1', 'user@example.com');
+VALUES 
+  ('like-1', 'seed-1', 'user@example.com'),
+  ('like-2', 'seed-2', 'user@example.com'),
+  ('like-3', 'seed-3', 'user@example.com');
 
 INSERT INTO saved_posts (id, post_id, user_email)
-VALUES ('save-1', 'seed-1', 'user@example.com');
+VALUES 
+  ('save-1', 'seed-1', 'user@example.com');


### PR DESCRIPTION
## Summary
- update seed data to include hosted Unsplash image URLs and additional sample posts
- refresh seed likes/saved entries to match the new posts and give the demo user an avatar

## Testing
- npm run db:seed

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69288cfbf490832f8ed92b257a2ccb2d)