### PR TITLE
Raise nav bar stacking and centering

### DIFF
--- a/Layout.jsx
+++ b/Layout.jsx
@@ -116,7 +116,7 @@ export default function Layout({ children, currentPageName }) {
         </div>
       </header>
 
-      <main className={`pb-32 ${currentPageName === 'Timeline' ? 'pt-4' : 'pt-8'} relative z-10`}>{children}</main>
+      <main className={`pb-36 ${currentPageName === 'Timeline' ? 'pt-4' : 'pt-8'} relative z-10`}>{children}</main>
 
       <HouseRulesModal open={showHouseRules} onOpenChange={handleCloseRules} />
       <CreatePostModal
@@ -127,15 +127,18 @@ export default function Layout({ children, currentPageName }) {
 
       <nav
         aria-label="Hoofdnavigatie"
-        className="fixed inset-x-0 z-[60] flex justify-center px-4"
+        className="pointer-events-none fixed left-1/2 -translate-x-1/2 z-[120] flex justify-center"
         style={{
           paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.5rem)',
           bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)',
           top: 'auto',
         }}
       >
-        <div className="relative mx-auto max-w-3xl flex items-end justify-center w-full">
-          <div className="absolute inset-x-8 -bottom-6 h-16 rounded-full bg-serenity-400/25 blur-3xl dark:bg-serenity-300/20" aria-hidden />
+        <div className="relative mx-auto flex items-end justify-center px-4 pointer-events-auto w-[min(calc(100vw-1.5rem),960px)]">
+          <div
+            className="absolute left-1/2 -translate-x-1/2 -bottom-6 h-16 w-[min(calc(100vw-1.5rem),960px)] rounded-full bg-serenity-400/25 blur-3xl dark:bg-serenity-300/20"
+            aria-hidden
+          />
           <div className="relative flex items-end justify-center gap-3 rounded-full border-2 border-white/90 dark:border-midnight-50/60 bg-gradient-to-br from-white/98 via-white/95 to-serenity-50/95 dark:from-midnight-50/90 dark:via-midnight-100/85 dark:to-midnight-50/80 px-3 py-2 shadow-[0_20px_70px_rgba(15,23,42,0.25)] ring-1 ring-serenity-200/70 dark:ring-midnight-50/40 backdrop-blur-2xl supports-[backdrop-filter]:bg-white/92">
             <div className="flex items-center justify-between gap-1">
               {tabItems.map((item) => {


### PR DESCRIPTION
## Summary
- increase the navigation bar stacking layer to sit above content
- constrain the nav and glow widths with centered, viewport-based sizing
- maintain safe-area padding while keeping the bar fixed at the bottom center

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d5c765514832f86f343df6cbc9169)