### PR TITLE
Stack create-post modal and sensitive warnings

### DIFF
--- a/Components/CreatePostModal.jsx
+++ b/Components/CreatePostModal.jsx
@@ -15,56 +15,18 @@ import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { UploadFile, InvokeLLM } from '../src/integrations/Core';
 import { User } from '../entities/User.js';
-import { Camera, X, Shield, Loader2 } from 'lucide-react';
+import { Camera, X, Shield, Loader2, EyeOff } from 'lucide-react';
 import { Checkbox } from '@/components/ui/checkbox';
 import PropTypes from 'prop-types';
-
-const photographyStyles = [
-  { id: 'portrait', label: 'Portrait' },
-  { id: 'fashion', label: 'Fashion' },
-  { id: 'boudoir', label: 'Boudoir', autoTrigger: ['artistic_nudity'] },
-  { id: 'art_nude', label: 'Art Nude', autoTrigger: ['artistic_nudity'] },
-  { id: 'street', label: 'Street' },
-  { id: 'landscape', label: 'Landscape' },
-  { id: 'nature', label: 'Nature' },
-  { id: 'conceptual', label: 'Conceptual' },
-  { id: 'editorial', label: 'Editorial' },
-  { id: 'fine_art', label: 'Fine Art' },
-  { id: 'wedding', label: 'Wedding' },
-  { id: 'sport', label: 'Sport' },
-  { id: 'advertising', label: 'Advertising' },
-  { id: 'beauty', label: 'Beauty' },
-  { id: 'lifestyle', label: 'Lifestyle' },
-  { id: 'documentary', label: 'Documentary' },
-  { id: 'travel', label: 'Travel' },
-  { id: 'architecture', label: 'Architecture' },
-  { id: 'macro', label: 'Macro' },
-  { id: 'wildlife', label: 'Wildlife' },
-  { id: 'food', label: 'Food' },
-  { id: 'product', label: 'Product' },
-  { id: 'automotive', label: 'Automotive' },
-  { id: 'event', label: 'Event' },
-  { id: 'corporate', label: 'Corporate' },
-  { id: 'maternity', label: 'Maternity' },
-  { id: 'family', label: 'Family' },
-  { id: 'children', label: 'Children' },
-  { id: 'pet', label: 'Pet' },
-  { id: 'black_white', label: 'Black & White' },
-  { id: 'abstract', label: 'Abstract' },
-  { id: 'surreal', label: 'Surreal' },
-  { id: 'vintage', label: 'Vintage' },
-  { id: 'minimalist', label: 'Minimalist' },
-  { id: 'candid', label: 'Candid' },
-  { id: 'glamour', label: 'Glamour' },
-];
+import { getStylePillClasses, photographyStyles } from '../utils/photographyStyles';
 
 const triggerWarnings = [
-  { id: 'artistic_nudity', label: 'Artistiek naakt' },
+  { id: 'artistic_nudity', label: 'Naakt' },
   { id: 'blood', label: 'Bloed' },
   { id: 'violence', label: 'Geweld' },
   { id: 'drugs', label: 'Drugs' },
-  { id: 'alcohol', label: 'Alcohol' },
-  { id: 'smoking', label: 'Roken' },
+  { id: 'medical', label: 'Ziekte / medisch' },
+  { id: 'self_harm', label: 'Zelfbeschadiging' },
 ];
 
 const roleLabels = {
@@ -83,6 +45,8 @@ export default function CreatePostModal({ open, onOpenChange, onPostCreated }) {
   const [contentError, setContentError] = useState(null);
   const [currentUser, setCurrentUser] = useState(null);
   const [autoTagUser, setAutoTagUser] = useState(true);
+  const [showAllStyles, setShowAllStyles] = useState(false);
+  const [validationMessage, setValidationMessage] = useState('');
   const [newPost, setNewPost] = useState({
     title: '',
     caption: '',
@@ -127,6 +91,12 @@ export default function CreatePostModal({ open, onOpenChange, onPostCreated }) {
       }));
     }
   }, [newPost.tags, newPost.photography_style, newPost.trigger_warnings]); // Added newPost.trigger_warnings to dependencies to fix warning and ensure current state is used.
+
+  useEffect(() => {
+    if (newPost.title && newPost.image_url && newPost.photography_style && validationMessage) {
+      setValidationMessage('');
+    }
+  }, [newPost.title, newPost.image_url, newPost.photography_style, validationMessage]);
 
   const analyzeImageContent = async (imageUrl) => {
     setAnalyzing(true);
@@ -176,13 +146,6 @@ export default function CreatePostModal({ open, onOpenChange, onPostCreated }) {
     setUploading(false);
   };
 
-  const handleTagClick = (tagId) =>
-    setNewPost((prev) => ({
-      ...prev,
-      tags: prev.tags.includes(tagId)
-        ? prev.tags.filter((t) => t !== tagId)
-        : [...prev.tags, tagId],
-    }));
   const handleTriggerClick = (triggerId) =>
     setNewPost((prev) => ({
       ...prev,
@@ -207,7 +170,19 @@ export default function CreatePostModal({ open, onOpenChange, onPostCreated }) {
     }));
 
   const handleCreatePost = async () => {
-    if (!newPost.title || !newPost.image_url || !newPost.photography_style) return;
+    if (!newPost.title || !newPost.image_url || !newPost.photography_style) {
+      const missing = [
+        !newPost.image_url && 'een foto',
+        !newPost.title && 'een titel',
+        !newPost.photography_style && 'een hoofdstijl',
+      ]
+        .filter(Boolean)
+        .join(', ');
+      setValidationMessage(`Plaatsen kan pas nadat je ${missing} hebt gekozen.`);
+      return;
+    }
+
+    setValidationMessage('');
 
     let finalTaggedPeople = [...newPost.tagged_people];
 
@@ -248,7 +223,7 @@ export default function CreatePostModal({ open, onOpenChange, onPostCreated }) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[95vh] overflow-y-auto">
+      <DialogContent className="max-w-5xl max-h-[95vh] overflow-y-auto">
         <DialogHeader>
           <div className="flex items-start justify-between gap-4">
             <DialogTitle className="text-2xl font-bold text-blue-900 flex items-center">
@@ -275,227 +250,260 @@ export default function CreatePostModal({ open, onOpenChange, onPostCreated }) {
             </Alert>
           )}
 
-          <div>
-            <Label htmlFor="image" className="text-lg font-semibold">
-              Foto uploaden *
-            </Label>
-            <div className="mt-2">
-              <input
-                id="image"
-                type="file"
-                accept="image/*"
-                onChange={handleImageUpload}
-                className="hidden"
-              />
-              {!newPost.image_url ? (
-                <Button
-                  variant="outline"
-                  onClick={() => document.getElementById('image')?.click()}
-                  className="w-full h-40 border-dashed border-2 border-slate-300 hover:border-blue-400 bg-slate-50"
-                  disabled={uploading || analyzing}
-                >
-                  <div className="text-center">
-                    {analyzing ? (
-                      <>
-                        <Loader2 className="w-12 h-12 mx-auto mb-3 text-blue-500 animate-spin" />
-                        <p className="text-lg font-medium">Analyseren van inhoud...</p>
-                      </>
-                    ) : uploading ? (
-                      <>
-                        <Loader2 className="w-12 h-12 mx-auto mb-3 text-blue-500 animate-spin" />
-                        <p className="text-lg font-medium">Uploaden...</p>
-                      </>
-                    ) : (
-                      <>
-                        <Camera className="w-12 h-12 mx-auto mb-3 text-slate-400" />
-                        <p className="text-lg font-medium">Selecteer een foto</p>
-                      </>
-                    )}
-                  </div>
-                </Button>
-              ) : (
-                <div className="relative">
-                  <img
-                    src={newPost.image_url}
-                    alt="Preview"
-                    className="w-full max-h-64 object-cover rounded-lg border"
-                  />
+          <div className="space-y-4">
+            <div className="rounded-2xl border border-slate-200 bg-white shadow-sm p-4 lg:p-6 space-y-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label htmlFor="image" className="text-lg font-semibold">
+                    Foto uploaden
+                  </Label>
+                  <p className="text-sm text-slate-500">Selecteer of vervang de hoofdfoto.</p>
+                </div>
+                {newPost.image_url && (
                   <Button
-                    variant="secondary"
+                    variant="outline"
                     size="sm"
                     onClick={() => document.getElementById('image')?.click()}
-                    className="absolute top-2 right-2"
                     disabled={analyzing}
                   >
                     {analyzing ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : null}Wijzig
-                    foto
                   </Button>
+                )}
+              </div>
+              <div className="mt-1">
+                <input
+                  id="image"
+                  type="file"
+                  accept="image/*"
+                  onChange={handleImageUpload}
+                  className="hidden"
+                />
+                {!newPost.image_url ? (
+                  <Button
+                    variant="outline"
+                    onClick={() => document.getElementById('image')?.click()}
+                    className="w-full h-48 border-dashed border-2 border-slate-300 hover:border-blue-400 bg-slate-50"
+                    disabled={uploading || analyzing}
+                  >
+                    <div className="text-center" aria-hidden>
+                      {analyzing ? (
+                        <Loader2 className="w-12 h-12 mx-auto mb-3 text-blue-500 animate-spin" />
+                      ) : uploading ? (
+                        <Loader2 className="w-12 h-12 mx-auto mb-3 text-blue-500 animate-spin" />
+                      ) : (
+                        <Camera className="w-12 h-12 mx-auto text-slate-400" />
+                      )}
+                    </div>
+                    <span className="sr-only">Kies een foto</span>
+                  </Button>
+                ) : (
+                  <div className="relative overflow-hidden rounded-xl border bg-slate-50">
+                    <img
+                      src={newPost.image_url}
+                      alt="Preview"
+                      className="w-full max-h-72 object-cover"
+                    />
+                    {newPost.trigger_warnings.length > 0 && (
+                      <div className="absolute inset-0 bg-slate-900/70 backdrop-blur-sm text-white flex flex-col items-center justify-center gap-2">
+                        <EyeOff className="w-8 h-8" />
+                        <p className="text-sm font-semibold">Sensitive cover actief</p>
+                      </div>
+                    )}
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => document.getElementById('image')?.click()}
+                      className="absolute top-3 right-3 shadow"
+                      disabled={analyzing}
+                    >
+                      {analyzing ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : null}Wijzig foto
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/50 bg-white/70 backdrop-blur-xl shadow-lg p-4 lg:p-6 space-y-5">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-slate-900">Stijlen</h3>
+                <span className="text-xs uppercase tracking-wide text-slate-400">Match</span>
+              </div>
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm text-slate-700">Hoofdstijl</p>
+                  {newPost.photography_style ? (
+                    <span className="text-xs text-slate-500">{newPost.photography_style}</span>
+                  ) : null}
+                </div>
+                <div className="flex flex-wrap gap-2 max-h-48 overflow-y-auto pr-1">
+                  {(showAllStyles ? photographyStyles : photographyStyles.slice(0, 10)).map(
+                    (style) => (
+                      <button
+                        key={style.id}
+                        type="button"
+                        onClick={() =>
+                          setNewPost((prev) => ({ ...prev, photography_style: style.id }))
+                        }
+                        className={`${getStylePillClasses(style.id, {
+                          active: newPost.photography_style === style.id,
+                        })} whitespace-nowrap px-4 py-2 text-sm font-semibold`}
+                      >
+                        {style.label}
+                      </button>
+                    ),
+                  )}
+                </div>
+                {photographyStyles.length > 10 && (
+                  <div className="flex justify-end">
+                    <Button variant="ghost" size="sm" onClick={() => setShowAllStyles((p) => !p)}>
+                      {showAllStyles ? 'Minder' : 'Meer'}
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/50 bg-white/70 backdrop-blur-xl shadow-lg p-4 lg:p-6 space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-slate-900">Waarschuwingen</h3>
+                <span className="text-xs uppercase tracking-wide text-slate-400">Content</span>
+              </div>
+              <p className="text-sm text-slate-600">
+                Kies passende waarschuwingen; bij een gevoelige keuze wordt automatisch een cover over de foto geplaatst.
+              </p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                {triggerWarnings.map((warning) => (
+                  <Button
+                    key={warning.id}
+                    variant={
+                      newPost.trigger_warnings.includes(warning.id) ? 'destructive' : 'outline'
+                    }
+                    size="sm"
+                    onClick={() => handleTriggerClick(warning.id)}
+                    className="text-xs"
+                  >
+                    {warning.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white shadow-sm p-4 lg:p-6 space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-slate-900">Titel & beschrijving</h3>
+                <span className="text-xs uppercase tracking-wide text-slate-400">Details</span>
+              </div>
+              <div className="space-y-2">
+                <Label className="text-sm font-medium text-slate-700">Titel</Label>
+                <Input
+                  value={newPost.title}
+                  onChange={(e) => setNewPost((prev) => ({ ...prev, title: e.target.value }))}
+                  placeholder="Geef je post een titel"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label className="text-sm font-medium text-slate-700">Beschrijving</Label>
+                <Textarea
+                  value={newPost.caption}
+                  onChange={(e) => setNewPost((prev) => ({ ...prev, caption: e.target.value }))}
+                  placeholder="Vertel iets over deze foto"
+                  className="min-h-[140px]"
+                />
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white shadow-sm p-4 lg:p-6 space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-slate-900">Credits & tagging</h3>
+                <span className="text-xs uppercase tracking-wide text-slate-400">Team</span>
+              </div>
+
+              <div className="flex items-start gap-3 p-3 rounded-xl bg-slate-50 border border-slate-100">
+                <Checkbox
+                  id="autoTag"
+                  checked={autoTagUser}
+                  onCheckedChange={setAutoTagUser}
+                  className="mt-1"
+                />
+                <div className="flex-1">
+                  <label htmlFor="autoTag" className="text-sm font-medium cursor-pointer">
+                    Voeg mij automatisch toe (model, jij)
+                  </label>
+                  {currentUser &&
+                    autoTagUser &&
+                    currentUser.roles &&
+                    currentUser.roles.length > 0 && (
+                      <div className="mt-2 text-xs text-slate-600">
+                        Je wordt toegevoegd als:{' '}
+                        {currentUser.roles.map((r) => roleLabels[r] || r).join(', ')}
+                      </div>
+                    )}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                <Input
+                  placeholder="Naam (model)"
+                  value={newPersonTag.name}
+                  onChange={(e) => setNewPersonTag((prev) => ({ ...prev, name: e.target.value }))}
+                />
+                <Select
+                  value={newPersonTag.role}
+                  onValueChange={(value) => setNewPersonTag((prev) => ({ ...prev, role: value }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="photographer">Fotograaf</SelectItem>
+                    <SelectItem value="model">Model</SelectItem>
+                    <SelectItem value="artist">Artist</SelectItem>
+                    <SelectItem value="makeup_artist">MUA</SelectItem>
+                    <SelectItem value="stylist">Stylist</SelectItem>
+                    <SelectItem value="assistant">Assistent</SelectItem>
+                    <SelectItem value="other">Overig</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Input
+                  placeholder="(Optioneel) link/portfolio"
+                  value={newPersonTag.instagram}
+                  onChange={(e) => setNewPersonTag((prev) => ({ ...prev, instagram: e.target.value }))}
+                />
+              </div>
+              <Button onClick={addPersonTag} size="sm" variant="secondary" className="w-full">
+                Toevoegen
+              </Button>
+
+              {newPost.tagged_people.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {newPost.tagged_people.map((person, index) => (
+                    <Badge key={index} variant="outline" className="flex items-center gap-2">
+                      {person.name} ({roleLabels[person.role]})
+                      <button onClick={() => removePersonTag(index)}>
+                        <X className="w-3 h-3" />
+                      </button>
+                    </Badge>
+                  ))}
                 </div>
               )}
             </div>
           </div>
 
-          <div className="space-y-4">
-            <Input
-              value={newPost.title}
-              onChange={(e) => setNewPost((prev) => ({ ...prev, title: e.target.value }))}
-              placeholder="Geef je post een titel *"
-            />
-            <Textarea
-              value={newPost.caption}
-              onChange={(e) => setNewPost((prev) => ({ ...prev, caption: e.target.value }))}
-              placeholder="Beschrijving"
-              className="min-h-[100px]"
-            />
-          </div>
-
-          <div className="border rounded-lg p-4 bg-slate-50">
-            <h3 className="font-semibold text-base mb-3">Credits automatiseren</h3>
-
-            <div className="flex items-start space-x-3 mb-4">
-              <Checkbox
-                id="autoTag"
-                checked={autoTagUser}
-                onCheckedChange={setAutoTagUser}
-                className="mt-1"
-              />
-              <div className="flex-1">
-                <label htmlFor="autoTag" className="text-sm font-medium cursor-pointer">
-                  Voeg mij automatisch toe (model, jij)
-                </label>
-                {currentUser &&
-                  autoTagUser &&
-                  currentUser.roles &&
-                  currentUser.roles.length > 0 && (
-                    <div className="mt-2 text-xs text-slate-600">
-                      Je wordt toegevoegd als:{' '}
-                      {currentUser.roles.map((r) => roleLabels[r] || r).join(', ')}
-                    </div>
-                  )}
-              </div>
-            </div>
-
-            <Label className="text-sm mb-2 block">Tag</Label>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-3">
-              <Input
-                placeholder="Naam (model)"
-                value={newPersonTag.name}
-                onChange={(e) => setNewPersonTag((prev) => ({ ...prev, name: e.target.value }))}
-              />
-              <Select
-                value={newPersonTag.role}
-                onValueChange={(value) => setNewPersonTag((prev) => ({ ...prev, role: value }))}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="photographer">Fotograaf</SelectItem>
-                  <SelectItem value="model">Model</SelectItem>
-                  <SelectItem value="artist">Artist</SelectItem>
-                  <SelectItem value="makeup_artist">MUA</SelectItem>
-                  <SelectItem value="stylist">Stylist</SelectItem>
-                  <SelectItem value="assistant">Assistent</SelectItem>
-                  <SelectItem value="other">Overig</SelectItem>
-                </SelectContent>
-              </Select>
-              <Input
-                placeholder="(Optioneel) link/portfolio"
-                value={newPersonTag.instagram}
-                onChange={(e) =>
-                  setNewPersonTag((prev) => ({ ...prev, instagram: e.target.value }))
-                }
-              />
-            </div>
-            <Button onClick={addPersonTag} size="sm" variant="secondary" className="w-full">
-              Toevoegen
-            </Button>
-
-            {newPost.tagged_people.length > 0 && (
-              <div className="flex flex-wrap gap-2 mt-3">
-                {newPost.tagged_people.map((person, index) => (
-                  <Badge key={index} variant="outline" className="flex items-center gap-2">
-                    {person.name} ({roleLabels[person.role]})
-                    <button onClick={() => removePersonTag(index)}>
-                      <X className="w-3 h-3" />
-                    </button>
-                  </Badge>
-                ))}
-              </div>
-            )}
-          </div>
-
-          <div>
-            <Label className="text-base font-semibold mb-3 block">Fotografiestijlen</Label>
-            <Select
-              value={newPost.photography_style}
-              onValueChange={(value) =>
-                setNewPost((prev) => ({ ...prev, photography_style: value }))
-              }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Hoofdstijl *" />
-              </SelectTrigger>
-              <SelectContent>
-                {photographyStyles.map((style) => (
-                  <SelectItem key={style.id} value={style.id}>
-                    {style.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <div className="grid grid-cols-4 gap-2 mt-3">
-              {photographyStyles.slice(0, 12).map((style) => (
-                <Button
-                  key={style.id}
-                  variant={newPost.tags.includes(style.id) ? 'default' : 'outline'}
-                  size="sm"
-                  onClick={() => handleTagClick(style.id)}
-                  className="text-xs"
-                >
-                  {style.label}
-                </Button>
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <Label className="text-base font-semibold mb-3 block">Waarschuwingen</Label>
-            <div className="grid grid-cols-3 gap-2">
-              {triggerWarnings.map((warning) => (
-                <Button
-                  key={warning.id}
-                  variant={
-                    newPost.trigger_warnings.includes(warning.id) ? 'destructive' : 'outline'
-                  }
-                  size="sm"
-                  onClick={() => handleTriggerClick(warning.id)}
-                  className="text-xs"
-                >
-                  {warning.label}
-                </Button>
-              ))}
-            </div>
-          </div>
-
-          <div className="flex justify-end space-x-3 pt-6 border-t border-slate-200">
-            <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <div className="flex flex-col gap-3 pt-4 border-t border-slate-200 sm:flex-row sm:justify-end">
+            <Button variant="outline" onClick={() => onOpenChange(false)} className="sm:min-w-[140px]">
               Annuleren
             </Button>
             <Button
               onClick={handleCreatePost}
-              disabled={
-                !newPost.title ||
-                !newPost.image_url ||
-                !newPost.photography_style ||
-                analyzing ||
-                !!contentError
-              }
-              className="bg-blue-800 hover:bg-blue-900 min-w-[120px]"
+              disabled={analyzing || !!contentError}
+              className="bg-blue-800 hover:bg-blue-900 sm:min-w-[160px]"
             >
               {analyzing ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : null}Foto delen
             </Button>
           </div>
+          {validationMessage && (
+            <p className="text-sm text-red-600 text-right">{validationMessage}</p>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/Components/PostCard.jsx
+++ b/Components/PostCard.jsx
@@ -8,6 +8,7 @@ import {
   isPostInMoodboard,
   removePostFromMoodboard,
 } from '../utils/moodboardStorage';
+import { getStyleTone, photographyStyles } from '../utils/photographyStyles';
 
 export default function PostCard({ post, onSaveToMoodboard }) {
   const [liked, setLiked] = useState(false);
@@ -50,6 +51,14 @@ export default function PostCard({ post, onSaveToMoodboard }) {
     if (post?.photography_style) return [post.photography_style];
     return [];
   }, [post?.tags, post?.photography_style]);
+
+  const styleLabelMap = useMemo(() => {
+    const map = {};
+    photographyStyles.forEach((style) => {
+      map[style.id] = style.label;
+    });
+    return map;
+  }, []);
 
   const comments = post?.comments_count ?? post?.comment_count ?? 0;
   const image = post?.image_url;
@@ -96,15 +105,6 @@ export default function PostCard({ post, onSaveToMoodboard }) {
 
     return stack;
   }, [post?.photographer_name, post?.tagged_people, roleLabels]);
-
-  const tagPalette = [
-    'from-sky-100 to-sky-300',
-    'from-cyan-100 to-cyan-300',
-    'from-blue-100 to-blue-300',
-    'from-indigo-100 to-indigo-300',
-    'from-violet-100 to-violet-300',
-    'from-purple-100 to-purple-300',
-  ];
 
   useEffect(() => {
     setImageLoaded(false);
@@ -212,14 +212,15 @@ export default function PostCard({ post, onSaveToMoodboard }) {
 
         {tags?.length > 0 && (
           <div className="mt-auto flex flex-wrap gap-2 pt-2">
-            {tags.slice(0, 6).map((tag, index) => {
-              const colors = tagPalette[index % tagPalette.length];
+            {tags.slice(0, 6).map((tag) => {
+              const tone = getStyleTone(tag);
+              const label = styleLabelMap[tag] || tag;
               return (
                 <span
                   key={tag}
-                  className={`text-xs font-semibold text-midnight-900 dark:text-midnight-900 px-3 py-1 rounded-full bg-gradient-to-r ${colors} shadow-soft border border-white/60 dark:border-white/20`}
+                  className={`text-xs font-semibold px-3 py-1 rounded-full bg-gradient-to-r ${tone.gradient} ${tone.text} shadow-soft border ${tone.border} ring-1 ring-white/70`}
                 >
-                  {tag}
+                  {label}
                 </span>
               );
             })}

--- a/Pages/Discover.jsx
+++ b/Pages/Discover.jsx
@@ -12,45 +12,46 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import PostCard from "../Components/PostCard";
 import { samplePosts, sampleUsers } from "../utils/dummyData";
 import { DUMMY_DATA_ENABLED } from "../utils/featureFlags";
+import { getStylePillClasses, photographyStyles } from "../utils/photographyStyles";
 
-const photographyStyles = [
-  { id: "portrait", label: "Portrait", icon: "👤" }, 
-  { id: "fashion", label: "Fashion", icon: "👗" },
-  { id: "boudoir", label: "Boudoir", icon: "🌹" }, 
-  { id: "art_nude", label: "Art Nude", icon: "🎨" },
-  { id: "street", label: "Street", icon: "🏙️" }, 
-  { id: "landscape", label: "Landscape", icon: "🏔️" },
-  { id: "nature", label: "Nature", icon: "🌿" }, 
-  { id: "conceptual", label: "Conceptual", icon: "💡" },
-  { id: "editorial", label: "Editorial", icon: "📰" }, 
-  { id: "fine_art", label: "Fine Art", icon: "🎨" },
-  { id: "wedding", label: "Wedding", icon: "💒" }, 
-  { id: "sport", label: "Sport", icon: "⚽" },
-  { id: "advertising", label: "Advertising", icon: "📢" }, 
-  { id: "beauty", label: "Beauty", icon: "💄" },
-  { id: "lifestyle", label: "Lifestyle", icon: "☀️" }, 
-  { id: "documentary", label: "Documentary", icon: "📹" },
-  { id: "travel", label: "Travel", icon: "✈️" }, 
-  { id: "architecture", label: "Architecture", icon: "🏛️" },
-  { id: "macro", label: "Macro", icon: "🔬" }, 
-  { id: "wildlife", label: "Wildlife", icon: "🦁" },
-  { id: "food", label: "Food", icon: "🍽️" }, 
-  { id: "product", label: "Product", icon: "📦" },
-  { id: "automotive", label: "Automotive", icon: "🚗" }, 
-  { id: "event", label: "Event", icon: "🎉" },
-  { id: "corporate", label: "Corporate", icon: "💼" }, 
-  { id: "maternity", label: "Maternity", icon: "🤱" },
-  { id: "family", label: "Family", icon: "👨‍👩‍👧‍👦" }, 
-  { id: "children", label: "Children", icon: "👶" },
-  { id: "pet", label: "Pet", icon: "🐕" }, 
-  { id: "black_white", label: "Black & White", icon: "⚫" },
-  { id: "abstract", label: "Abstract", icon: "🌀" }, 
-  { id: "surreal", label: "Surreal", icon: "🌙" },
-  { id: "vintage", label: "Vintage", icon: "📷" }, 
-  { id: "minimalist", label: "Minimalist", icon: "⭕" },
-  { id: "candid", label: "Candid", icon: "📸" }, 
-  { id: "glamour", label: "Glamour", icon: "💎" }
-];
+const styleIcons = {
+  portrait: "👤",
+  fashion: "👗",
+  boudoir: "🌹",
+  art_nude: "🎨",
+  street: "🏙️",
+  landscape: "🏔️",
+  nature: "🌿",
+  conceptual: "💡",
+  editorial: "📰",
+  fine_art: "🎨",
+  wedding: "💒",
+  sport: "⚽",
+  advertising: "📢",
+  beauty: "💄",
+  lifestyle: "☀️",
+  documentary: "📹",
+  travel: "✈️",
+  architecture: "🏛️",
+  macro: "🔬",
+  wildlife: "🦁",
+  food: "🍽️",
+  product: "📦",
+  automotive: "🚗",
+  event: "🎉",
+  corporate: "💼",
+  maternity: "🤱",
+  family: "👨‍👩‍👧‍👦",
+  children: "👶",
+  pet: "🐕",
+  black_white: "⚫",
+  abstract: "🌀",
+  surreal: "🌙",
+  vintage: "📷",
+  minimalist: "⭕",
+  candid: "📸",
+  glamour: "💎",
+};
 
 const userRoles = [
   { id: "all", label: "Alle" }, 
@@ -183,11 +184,11 @@ const StylesTab = ({ searchTerm }) => {
   return (
     <div className="px-4">
       {/* Style Filter Pills */}
-      <div className="flex flex-wrap gap-3 mb-6">
+      <div className="flex flex-wrap gap-3 mb-6 overflow-x-auto pb-2">
         <Button
           variant={!selectedStyle ? 'default' : 'outline'}
           onClick={() => setSelectedStyle(null)}
-          className={`rounded-full px-4 py-2 ${
+          className={`rounded-full px-4 py-2 shrink-0 ${
             !selectedStyle
               ? 'bg-serenity-600 text-white shadow-soft'
               : 'bg-white/80 text-midnight-900 dark:text-serenity-50 border-serenity-200/70'
@@ -196,19 +197,17 @@ const StylesTab = ({ searchTerm }) => {
           Alles
         </Button>
         {visibleStyles.map(style => (
-          <Button
+          <button
             key={style.id}
-            variant={selectedStyle === style.id ? 'default' : 'outline'}
+            type="button"
             onClick={() => setSelectedStyle(style.id)}
-            className={`rounded-full px-4 py-2 ${
-              selectedStyle === style.id
-                ? 'bg-serenity-600 text-white shadow-soft'
-                : 'bg-white/80 text-midnight-900 dark:text-serenity-50 border-serenity-200/70'
-            }`}
+            className={`shrink-0 flex items-center gap-2 px-4 py-2 text-sm font-semibold ${getStylePillClasses(style.id, {
+              active: selectedStyle === style.id,
+            })}`}
           >
-            <span className="mr-1">{style.icon}</span>
+            <span className="mr-1">{styleIcons[style.id]}</span>
             {style.label}
-          </Button>
+          </button>
         ))}
         {!showAllStyles && photographyStyles.length > 5 && (
           <Button

--- a/utils/photographyStyles.js
+++ b/utils/photographyStyles.js
@@ -1,0 +1,110 @@
+export const photographyStyles = [
+  { id: 'portrait', label: 'Portrait' },
+  { id: 'fashion', label: 'Fashion' },
+  { id: 'boudoir', label: 'Boudoir', autoTrigger: ['artistic_nudity'] },
+  { id: 'art_nude', label: 'Art Nude', autoTrigger: ['artistic_nudity'] },
+  { id: 'street', label: 'Street' },
+  { id: 'landscape', label: 'Landscape' },
+  { id: 'nature', label: 'Nature' },
+  { id: 'conceptual', label: 'Conceptual' },
+  { id: 'editorial', label: 'Editorial' },
+  { id: 'fine_art', label: 'Fine Art' },
+  { id: 'wedding', label: 'Wedding' },
+  { id: 'sport', label: 'Sport' },
+  { id: 'advertising', label: 'Advertising' },
+  { id: 'beauty', label: 'Beauty' },
+  { id: 'lifestyle', label: 'Lifestyle' },
+  { id: 'documentary', label: 'Documentary' },
+  { id: 'travel', label: 'Travel' },
+  { id: 'architecture', label: 'Architecture' },
+  { id: 'macro', label: 'Macro' },
+  { id: 'wildlife', label: 'Wildlife' },
+  { id: 'food', label: 'Food' },
+  { id: 'product', label: 'Product' },
+  { id: 'automotive', label: 'Automotive' },
+  { id: 'event', label: 'Event' },
+  { id: 'corporate', label: 'Corporate' },
+  { id: 'maternity', label: 'Maternity' },
+  { id: 'family', label: 'Family' },
+  { id: 'children', label: 'Children' },
+  { id: 'pet', label: 'Pet' },
+  { id: 'black_white', label: 'Black & White' },
+  { id: 'abstract', label: 'Abstract' },
+  { id: 'surreal', label: 'Surreal' },
+  { id: 'vintage', label: 'Vintage' },
+  { id: 'minimalist', label: 'Minimalist' },
+  { id: 'candid', label: 'Candid' },
+  { id: 'glamour', label: 'Glamour' },
+];
+
+const colorPalette = [
+  { gradient: 'from-rose-50 via-rose-100 to-rose-200', text: 'text-rose-900', border: 'border-rose-100', ring: 'ring-rose-200/70' },
+  { gradient: 'from-sky-50 via-sky-100 to-sky-200', text: 'text-sky-900', border: 'border-sky-100', ring: 'ring-sky-200/70' },
+  { gradient: 'from-amber-50 via-amber-100 to-amber-200', text: 'text-amber-900', border: 'border-amber-100', ring: 'ring-amber-200/70' },
+  { gradient: 'from-emerald-50 via-emerald-100 to-emerald-200', text: 'text-emerald-900', border: 'border-emerald-100', ring: 'ring-emerald-200/70' },
+  { gradient: 'from-indigo-50 via-indigo-100 to-indigo-200', text: 'text-indigo-900', border: 'border-indigo-100', ring: 'ring-indigo-200/70' },
+  { gradient: 'from-purple-50 via-purple-100 to-purple-200', text: 'text-purple-900', border: 'border-purple-100', ring: 'ring-purple-200/70' },
+  { gradient: 'from-teal-50 via-teal-100 to-teal-200', text: 'text-teal-900', border: 'border-teal-100', ring: 'ring-teal-200/70' },
+  { gradient: 'from-blue-50 via-blue-100 to-blue-200', text: 'text-blue-900', border: 'border-blue-100', ring: 'ring-blue-200/70' },
+  { gradient: 'from-orange-50 via-orange-100 to-orange-200', text: 'text-orange-900', border: 'border-orange-100', ring: 'ring-orange-200/70' },
+  { gradient: 'from-lime-50 via-lime-100 to-lime-200', text: 'text-lime-900', border: 'border-lime-100', ring: 'ring-lime-200/70' },
+  { gradient: 'from-pink-50 via-pink-100 to-pink-200', text: 'text-pink-900', border: 'border-pink-100', ring: 'ring-pink-200/70' },
+  { gradient: 'from-slate-50 via-slate-100 to-slate-200', text: 'text-slate-900', border: 'border-slate-100', ring: 'ring-slate-200/70' },
+];
+
+const styleColorMap = {
+  fashion: colorPalette[0],
+  portrait: colorPalette[1],
+  boudoir: colorPalette[2],
+  art_nude: colorPalette[2],
+  street: colorPalette[3],
+  landscape: colorPalette[4],
+  nature: colorPalette[3],
+  conceptual: colorPalette[5],
+  editorial: colorPalette[4],
+  fine_art: colorPalette[5],
+  wedding: colorPalette[8],
+  sport: colorPalette[7],
+  advertising: colorPalette[6],
+  beauty: colorPalette[10],
+  lifestyle: colorPalette[11],
+  documentary: colorPalette[6],
+  travel: colorPalette[1],
+  architecture: colorPalette[9],
+  macro: colorPalette[2],
+  wildlife: colorPalette[9],
+  food: colorPalette[8],
+  product: colorPalette[4],
+  automotive: colorPalette[7],
+  event: colorPalette[6],
+  corporate: colorPalette[11],
+  maternity: colorPalette[0],
+  family: colorPalette[0],
+  children: colorPalette[10],
+  pet: colorPalette[9],
+  black_white: colorPalette[11],
+  abstract: colorPalette[5],
+  surreal: colorPalette[5],
+  vintage: colorPalette[8],
+  minimalist: colorPalette[11],
+  candid: colorPalette[1],
+  glamour: colorPalette[10],
+};
+
+const hashStyle = (id) => {
+  return id.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
+};
+
+export const getStyleTone = (styleId) => {
+  if (!styleId) return colorPalette[0];
+  const mapped = styleColorMap[styleId];
+  if (mapped) return mapped;
+  const index = Math.abs(hashStyle(styleId)) % colorPalette.length;
+  return colorPalette[index];
+};
+
+export const getStylePillClasses = (styleId, { active } = {}) => {
+  const tone = getStyleTone(styleId);
+  const emphasis = active ? `ring-2 ${tone.ring} shadow-md` : 'shadow-sm';
+  return `bg-gradient-to-r ${tone.gradient} ${tone.text} border ${tone.border} ${emphasis} rounded-full transition-all duration-150`;
+};


### PR DESCRIPTION
## Summary
- stack the create-post modal sections vertically with clearer required-field validation and an icon-only uploader
- show the top photography styles as color pills with a “meer” toggle and remove the separate tag list
- expand sensitive warnings and apply an automatic cover when flagged or when selecting art nude

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d719a6cf8832fba10ad74d543404d)