### PR TITLE
Handle create post failures

### DIFF
--- a/Layout.jsx
+++ b/Layout.jsx
@@ -44,12 +44,8 @@ export default function Layout({ children, currentPageName }) {
   };
 
   const handlePostCreated = async (newPost) => {
-    try {
-      const createdPost = await Post.create(newPost);
-      window.dispatchEvent(new CustomEvent('post:created', { detail: createdPost || newPost }));
-    } catch (error) {
-      console.error('Error creating post:', error);
-    }
+    const createdPost = await Post.create(newPost);
+    window.dispatchEvent(new CustomEvent('post:created', { detail: createdPost || newPost }));
   };
 
   return (


### PR DESCRIPTION
## Summary
- let post creation errors propagate so the modal does not clear on failure
- dispatch post creation events only after a successful creation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1e9ff68c832f9601af15422d92d5)