### PR TITLE
Make bottom nav full width and anchored

### DIFF
--- a/Layout.jsx
+++ b/Layout.jsx
@@ -127,16 +127,19 @@ export default function Layout({ children, currentPageName }) {
 
       <nav
         aria-label="Hoofdnavigatie"
-        className="pointer-events-auto fixed left-1/2 -translate-x-1/2 z-[120] flex justify-center"
+        className="pointer-events-auto fixed inset-x-0 bottom-0 z-[120] flex justify-center"
         style={{
-          paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.5rem)',
-          bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)',
+          paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.75rem)',
           top: 'auto',
         }}
       >
-        <div className="pointer-events-auto relative w-full max-w-[960px] px-4">
+        <div
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-white/85 via-white/80 to-transparent dark:from-midnight-100/70 dark:via-midnight-100/60 dark:to-transparent backdrop-blur-2xl border-t border-serenity-200/60 dark:border-midnight-50/30 shadow-[0_-18px_50px_rgba(15,23,42,0.25)]"
+          aria-hidden
+        />
+        <div className="pointer-events-auto relative w-full max-w-[960px] px-4 pb-2">
           <div
-            className="absolute left-1/2 -translate-x-1/2 -bottom-6 h-16 w-[min(calc(100vw-1.5rem),960px)] rounded-full bg-serenity-400/25 blur-3xl dark:bg-serenity-300/20 pointer-events-none"
+            className="absolute inset-x-4 -bottom-5 h-16 rounded-full bg-serenity-400/25 blur-3xl dark:bg-serenity-300/20 pointer-events-none"
             aria-hidden
           />
           <div className="relative mx-auto flex items-end justify-center gap-3 rounded-full border-2 border-white/90 dark:border-midnight-50/60 bg-gradient-to-br from-white/98 via-white/95 to-serenity-50/95 dark:from-midnight-50/90 dark:via-midnight-100/85 dark:to-midnight-50/80 px-3 py-2 shadow-[0_20px_70px_rgba(15,23,42,0.25)] ring-1 ring-serenity-200/70 dark:ring-midnight-50/40 backdrop-blur-2xl supports-[backdrop-filter]:bg-white/92">


### PR DESCRIPTION
## Summary
- anchor the main navigation bar to the full viewport width at the bottom with safe-area padding
- extend gradient and shadow layers across the viewport without translations while keeping pill styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7db3fb38832f8960570dd43aa79e)