### PR TITLE
Add bottom navigation bar mirroring header actions

### DIFF
--- a/Layout.jsx
+++ b/Layout.jsx
@@ -127,20 +127,22 @@ export default function Layout({ children, currentPageName }) {
 
       <nav
         aria-label="Hoofdnavigatie"
-        className="pointer-events-auto fixed left-1/2 -translate-x-1/2 z-[120] flex justify-center"
-        style={{
-          paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.5rem)',
-          bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)',
-          top: 'auto',
-        }}
+        className="fixed inset-x-0 bottom-0 z-[120] backdrop-blur-xl bg-white/90 dark:bg-midnight-100/70 border-t border-serenity-200/60 dark:border-midnight-50/30 shadow-[0_-10px_40px_rgba(15,23,42,0.25)]"
+        style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.75rem)' }}
       >
-        <div className="pointer-events-auto relative w-full max-w-[960px] px-4">
-          <div
-            className="absolute left-1/2 -translate-x-1/2 -bottom-6 h-16 w-[min(calc(100vw-1.5rem),960px)] rounded-full bg-serenity-400/25 blur-3xl dark:bg-serenity-300/20 pointer-events-none"
-            aria-hidden
-          />
-          <div className="relative mx-auto flex items-end justify-center gap-3 rounded-full border-2 border-white/90 dark:border-midnight-50/60 bg-gradient-to-br from-white/98 via-white/95 to-serenity-50/95 dark:from-midnight-50/90 dark:via-midnight-100/85 dark:to-midnight-50/80 px-3 py-2 shadow-[0_20px_70px_rgba(15,23,42,0.25)] ring-1 ring-serenity-200/70 dark:ring-midnight-50/40 backdrop-blur-2xl supports-[backdrop-filter]:bg-white/92">
-            <div className="flex items-center justify-between gap-1">
+        <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between gap-4 py-3">
+            <Link to={PAGE_ROUTES.timeline} className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-2xl bg-gradient-to-br from-serenity-500 to-serenity-600 text-white flex items-center justify-center shadow-floating">
+                <LayoutGrid className="w-5 h-5" />
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-[0.2em] text-serenity-600 dark:text-serenity-200">Exhibit</p>
+                <p className="font-semibold text-lg text-midnight-900 dark:text-white">Creatieve community</p>
+              </div>
+            </Link>
+
+            <div className="flex flex-wrap justify-end items-center gap-2 sm:gap-3">
               {tabItems.map((item) => {
                 const isRootPath = item.path === PAGE_ROUTES.timeline;
                 const isActive =
@@ -153,10 +155,10 @@ export default function Layout({ children, currentPageName }) {
                   <Link
                     key={`${item.name}-${item.path}`}
                     to={item.path}
-                    className={`group flex items-center justify-center gap-2 rounded-full px-3 py-2 text-sm font-semibold transition-all duration-200 ${
+                    className={`group inline-flex items-center gap-2 rounded-full px-3 sm:px-4 py-2 text-sm font-semibold transition-all duration-200 border ${
                       isActive
-                        ? 'bg-serenity-600 text-white shadow-floating'
-                        : 'text-midnight-800 dark:text-slate-200 hover:bg-serenity-100/90 dark:hover:bg-midnight-50/30'
+                        ? 'bg-serenity-600 text-white border-serenity-600 shadow-floating'
+                        : 'bg-white/70 dark:bg-midnight-50/30 border-serenity-200/80 dark:border-midnight-50/40 text-midnight-900 dark:text-slate-100 hover:-translate-y-[1px] hover:shadow-soft'
                     }`}
                   >
                     {item.isProfile ? (
@@ -167,16 +169,16 @@ export default function Layout({ children, currentPageName }) {
                             : 'border-serenity-100 dark:border-midnight-50/40 group-hover:border-serenity-200'
                         }`}
                       >
-                        <Avatar className="w-9 h-9 border border-white/60 shadow-sm">
+                        <Avatar className="w-8 h-8 border border-white/60 shadow-sm">
                           <AvatarImage src={profileImage} className="object-cover" />
-                          <AvatarFallback className="text-sm font-semibold uppercase">
+                          <AvatarFallback className="text-xs font-semibold uppercase">
                             {user?.display_name?.[0] || <UserIcon className="w-4 h-4" />}
                           </AvatarFallback>
                         </Avatar>
                       </div>
                     ) : (
                       <IconComponent
-                        className={`w-5 h-5 transition-transform duration-200 ${
+                        className={`w-4 h-4 transition-transform duration-200 ${
                           isActive ? 'scale-110' : 'group-hover:scale-105'
                         }`}
                       />
@@ -185,18 +187,19 @@ export default function Layout({ children, currentPageName }) {
                   </Link>
                 );
               })}
-            </div>
 
-            {actionItem && (
-              <button
-                type="button"
-                onClick={actionItem.action}
-                aria-label={actionItem.name}
-                className="ml-2 pointer-events-auto flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-serenity-500 to-serenity-700 text-white shadow-floating transition-transform duration-200 hover:scale-105 focus:scale-105 focus:outline-none focus:ring-4 focus:ring-serenity-200"
-              >
-                {ActionIcon && <ActionIcon className="h-6 w-6" />}
-              </button>
-            )}
+              {actionItem && (
+                <button
+                  type="button"
+                  onClick={actionItem.action}
+                  aria-label={actionItem.name}
+                  className="inline-flex items-center gap-2 rounded-full bg-gradient-to-br from-serenity-500 to-serenity-700 text-white px-4 sm:px-5 py-2.5 font-semibold shadow-floating transition-transform duration-200 hover:scale-105 focus-visible:scale-105 focus:outline-none focus-visible:ring-4 focus-visible:ring-serenity-200"
+                >
+                  {ActionIcon && <ActionIcon className="h-5 w-5" />}
+                  <span>Upload foto</span>
+                </button>
+              )}
+            </div>
           </div>
         </div>
       </nav>


### PR DESCRIPTION
## Summary
- replace the bottom nav with a full-width, header-style bar pinned to the viewport bottom
- add brand context plus pill buttons for each page destination with active highlighting
- include a dedicated upload action button to open the create post flow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7db3fb38832f8960570dd43aa79e)