### PR TITLE
Add navigation links to header layout

### DIFF
--- a/Layout.jsx
+++ b/Layout.jsx
@@ -32,18 +32,55 @@ export default function Layout({ children, currentPageName }) {
 
       <header className="sticky top-0 z-40 backdrop-blur-xl bg-white/80 dark:bg-midnight-100/60 border-b border-serenity-200/60 dark:border-midnight-50/30 shadow-soft">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16 gap-3">
-            <Link to={PAGE_ROUTES.timeline} className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-2xl bg-gradient-to-br from-serenity-500 to-serenity-600 text-white flex items-center justify-center shadow-floating">
-                <LayoutGrid className="w-5 h-5" />
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-[0.2em] text-serenity-600 dark:text-serenity-200">Exhibit</p>
-                <p className="font-semibold text-lg text-midnight-900 dark:text-white">Creatieve community</p>
-              </div>
-            </Link>
+          <div className="flex justify-between items-center h-16 gap-6">
+            <div className="flex items-center gap-8">
+              <Link to={PAGE_ROUTES.timeline} className="flex items-center gap-3">
+                <div className="h-10 w-10 rounded-2xl bg-gradient-to-br from-serenity-500 to-serenity-600 text-white flex items-center justify-center shadow-floating">
+                  <LayoutGrid className="w-5 h-5" />
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-[0.2em] text-serenity-600 dark:text-serenity-200">Exhibit</p>
+                  <p className="font-semibold text-lg text-midnight-900 dark:text-white">Creatieve community</p>
+                </div>
+              </Link>
 
-            <div className="flex items-center gap-3">
+              <nav className="hidden md:flex items-center gap-1">
+                <Link to={PAGE_ROUTES.timeline}>
+                  <Button
+                    variant="ghost"
+                    className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
+                  >
+                    Galerij
+                  </Button>
+                </Link>
+                <Link to={PAGE_ROUTES.discover}>
+                  <Button
+                    variant="ghost"
+                    className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
+                  >
+                    Ontdekken
+                  </Button>
+                </Link>
+                <Link to={PAGE_ROUTES.community}>
+                  <Button
+                    variant="ghost"
+                    className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
+                  >
+                    Community
+                  </Button>
+                </Link>
+                <Link to={PAGE_ROUTES.profile}>
+                  <Button
+                    variant="ghost"
+                    className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
+                  >
+                    Profiel
+                  </Button>
+                </Link>
+              </nav>
+            </div>
+
+            <div className="flex items-center gap-2 sm:gap-3">
               <button
                 type="button"
                 onClick={toggleTheme}


### PR DESCRIPTION
## Summary
- add navigation buttons for Galerij, Ontdekken, Community, and Profiel in the layout header
- align navigation with the logo row and adjust spacing for header controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303d85b81c832f973acb5f263e7179)