### PR TITLE
Move theme toggle to profile page

### DIFF
--- a/Layout.jsx
+++ b/Layout.jsx
@@ -1,14 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { PAGE_ROUTES } from '@/utils';
-import { LayoutGrid, SunMedium, Moon } from 'lucide-react';
+import { LayoutGrid } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import HouseRulesModal from '@/components/HouseRulesModal';
-import { useTheme } from '@/context/ThemeContext';
 import PropTypes from 'prop-types';
 
 export default function Layout({ children, currentPageName }) {
-  const { theme, toggleTheme } = useTheme();
   const [showHouseRules, setShowHouseRules] = useState(false);
 
   useEffect(() => {
@@ -78,18 +76,6 @@ export default function Layout({ children, currentPageName }) {
                   </Button>
                 </Link>
               </nav>
-            </div>
-
-            <div className="flex items-center gap-2 sm:gap-3 flex-shrink-0">
-              <button
-                type="button"
-                onClick={toggleTheme}
-                className="inline-flex items-center gap-2 rounded-full px-3 py-2 bg-serenity-100 dark:bg-midnight-50/20 border border-serenity-200/70 dark:border-midnight-50/30 text-midnight-900 dark:text-white shadow-soft hover:-translate-y-[1px] transition"
-                aria-label="Schakel thema"
-              >
-                {theme === 'light' ? <SunMedium className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
-                <span className="hidden sm:inline text-sm font-semibold">{theme === 'light' ? 'Licht' : 'Donker'}</span>
-              </button>
             </div>
           </div>
         </div>

--- a/Pages/Profile.jsx
+++ b/Pages/Profile.jsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Edit, Bookmark, Camera, Grid, LogOut, Eye, EyeOff, Shield, BarChart2 } from "lucide-react";
+import { Edit, Bookmark, Camera, Grid, LogOut, Eye, EyeOff, Shield, BarChart2, SunMedium, Moon } from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -23,6 +23,7 @@ import { DUMMY_DATA_ENABLED } from "../utils/featureFlags";
 import { sampleMoodboardPosts, sampleProfile, sampleProfilePosts } from "../utils/dummyData";
 import { getMoodboardPosts } from "../utils/moodboardStorage";
 import { useAuth } from "@/context/AuthContext";
+import { useTheme } from "@/context/ThemeContext";
 
 const photographyStyles = [
   { id: "portrait", label: "Portrait" }, { id: "fashion", label: "Fashion" }, { id: "boudoir", label: "Boudoir" },
@@ -179,6 +180,7 @@ EditProfileDialog.propTypes = {
 
 export default function Profile() {
   const { user: authUser, loading: authLoading, logout } = useAuth();
+  const { theme, toggleTheme } = useTheme();
   const [user, setUser] = useState(null);
   const [userPosts, setUserPosts] = useState([]);
   const [savedPosts, setSavedPosts] = useState([]);
@@ -344,6 +346,15 @@ export default function Profile() {
                 <Link to={createPageUrl("Analytics")}>
                   <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" title="Statistieken"><BarChart2 className="w-5 h-5" /></Button>
                 </Link>
+                <Button
+                  variant="ghost"
+                  className="rounded-full bg-serenity-100 dark:bg-midnight-100/40 px-4 py-2 flex items-center gap-2"
+                  onClick={toggleTheme}
+                  title="Schakel thema"
+                >
+                  {theme === 'light' ? <SunMedium className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+                  <span className="text-sm font-semibold">Thema: {theme === 'light' ? 'Licht' : 'Donker'}</span>
+                </Button>
                 <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" onClick={toggleSensitiveContent} title={user.show_sensitive_content ? "Gevoelige content verbergen" : "Gevoelige content tonen"}>
                   {user.show_sensitive_content ? <Eye className="w-5 h-5" /> : <EyeOff className="w-5 h-5" />}
                 </Button>


### PR DESCRIPTION
## Summary
- remove the global header theme toggle from the shared layout
- add a clearly labelled theme toggle control to the profile actions row using the shared theme context

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693070510410832fba8462915f10418e)