### PR TITLE
Add primary role selection to profile

### DIFF
--- a/utils/dummyData.ts
+++ b/utils/dummyData.ts
@@ -195,6 +195,7 @@ export const sampleProfile = {
   bio: 'Fotograaf & creative director met een liefde voor zachte kleuren en storytelling.',
   avatar_url: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=400&q=80',
   roles: ['photographer', 'artist'],
+  primary_role: 'photographer',
   styles: ['fine_art', 'fashion', 'portrait'],
   show_sensitive_content: false,
   onboarding_complete: true,


### PR DESCRIPTION
## Summary
- add role tabs and primary role selection to the profile page so multi-role users can choose their default view
- persist the primary role choice via user data updates and reorder badges to highlight the preference
- update dummy profile data to include a primary role for previewing the feature

## Testing
- npm run lint (reports existing warning in Components/PostCard.jsx)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69307f75a668832fb87a02fd80a3e008)