### PR TITLE
Add agency and company roles across app data

### DIFF
--- a/Components/CreatePostModal.jsx
+++ b/Components/CreatePostModal.jsx
@@ -37,6 +37,8 @@ const roleLabels = {
   assistant: 'Assistent',
   other: 'Overig',
   artist: 'Artist',
+  agency: 'Agency',
+  company: 'Bedrijf',
 };
 
 export default function CreatePostModal({ open, onOpenChange, onPostCreated }) {
@@ -481,6 +483,8 @@ export default function CreatePostModal({ open, onOpenChange, onPostCreated }) {
                     <SelectItem value="makeup_artist">MUA</SelectItem>
                     <SelectItem value="stylist">Stylist</SelectItem>
                     <SelectItem value="assistant">Assistent</SelectItem>
+                    <SelectItem value="agency">Agency</SelectItem>
+                    <SelectItem value="company">Bedrijf</SelectItem>
                     <SelectItem value="other">Overig</SelectItem>
                   </SelectContent>
                 </Select>

--- a/Components/PostCard.jsx
+++ b/Components/PostCard.jsx
@@ -69,6 +69,8 @@ export default function PostCard({ post, onSaveToMoodboard }) {
       makeup_artist: 'MUA',
       stylist: 'Stylist',
       assistant: 'Assistent',
+      agency: 'Agency',
+      company: 'Bedrijf',
       other: 'Artiest',
     }),
     []
@@ -92,7 +94,7 @@ export default function PostCard({ post, onSaveToMoodboard }) {
       post.tagged_people.forEach((person) => {
         if (!person?.name) return;
         const label = roleLabels[person.role] || 'Artiest';
-        if (['Fotograaf', 'Model', 'MUA', 'Artiest'].includes(label)) {
+        if (['Fotograaf', 'Model', 'MUA', 'Artiest', 'Agency', 'Bedrijf'].includes(label)) {
           stack.push({
             role: label,
             name: person.name,

--- a/Pages/Login.tsx
+++ b/Pages/Login.tsx
@@ -17,6 +17,8 @@ const roleLabels: Record<string, string> = {
   stylist: 'Stylist',
   makeup_artist: 'MUA',
   assistant: 'Assistent',
+  agency: 'Agency',
+  company: 'Bedrijf',
 };
 
 const LoginPage: React.FC = () => {

--- a/Pages/Profile.jsx
+++ b/Pages/Profile.jsx
@@ -41,8 +41,15 @@ const photographyStyles = [
 ];
 
 const userRoles = [
-  { id: "photographer", label: "Fotograaf" }, { id: "model", label: "Model" }, { id: "makeup_artist", label: "Make-up Artist" },
-  { id: "stylist", label: "Stylist" }, { id: "artist", label: "Artist" }, { id: "assistant", label: "Assistent" }, { id: "other", label: "Overig" }
+  { id: "photographer", label: "Fotograaf" },
+  { id: "model", label: "Model" },
+  { id: "makeup_artist", label: "Make-up Artist" },
+  { id: "stylist", label: "Stylist" },
+  { id: "artist", label: "Artist" },
+  { id: "assistant", label: "Assistent" },
+  { id: "agency", label: "Agency" },
+  { id: "company", label: "Bedrijf" },
+  { id: "other", label: "Overig" }
 ];
 
 

--- a/utils/dummyAccounts.ts
+++ b/utils/dummyAccounts.ts
@@ -67,4 +67,26 @@ export const dummyAccounts = [
     }),
     label: 'Fashion & set-assist',
   },
+  {
+    email: 'studio.aurora@example.com',
+    password: 'agencyflow',
+    user: toAccountUser(sampleUsers[7], {
+      email: 'studio.aurora@example.com',
+      full_name: 'Studio Aurora Agency',
+      bio: 'Agency die creative teams matcht met nieuwe gezichten.',
+      onboarding_complete: true,
+    }),
+    label: 'Agency - castings',
+  },
+  {
+    email: 'northwind.media@example.com',
+    password: 'teamwork',
+    user: toAccountUser(sampleUsers[8], {
+      email: 'northwind.media@example.com',
+      full_name: 'Northwind Media',
+      bio: 'Bedrijf dat merkcampagnes en producties coördineert.',
+      onboarding_complete: true,
+    }),
+    label: 'Bedrijf - campagnes',
+  },
 ];

--- a/utils/dummyData.ts
+++ b/utils/dummyData.ts
@@ -148,6 +148,20 @@ export const sampleUsers = [
     styles: ['fashion', 'candid'],
     avatar_url: 'https://images.unsplash.com/photo-1519085360753-af0119f7cbe7?auto=format&fit=crop&w=320&q=80',
   },
+  {
+    id: 'sample-user-8',
+    display_name: 'Studio Aurora',
+    roles: ['agency'],
+    styles: ['fashion', 'editorial'],
+    avatar_url: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=320&q=80',
+  },
+  {
+    id: 'sample-user-9',
+    display_name: 'Northwind Media',
+    roles: ['company'],
+    styles: ['corporate', 'product'],
+    avatar_url: 'https://images.unsplash.com/photo-1450101215322-bf5cd27642fc?auto=format&fit=crop&w=320&q=80',
+  },
 ];
 
 export const sampleCommunities = [
@@ -194,7 +208,7 @@ export const sampleProfile = {
   full_name: 'Nova Lint',
   bio: 'Fotograaf & creative director met een liefde voor zachte kleuren en storytelling.',
   avatar_url: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=400&q=80',
-  roles: ['photographer', 'artist'],
+  roles: ['photographer', 'artist', 'agency'],
   primary_role: 'photographer',
   styles: ['fine_art', 'fashion', 'portrait'],
   show_sensitive_content: false,


### PR DESCRIPTION
## Summary
- add agency and company role labels across profile editing, login badges, post tagging, and post cards
- extend demo users, profile seed data, and dummy accounts with agency and company entries
- update tagged-people options to include new organisational roles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69308108d338832fab589bb8081afa77)