### PR TITLE
Add agency and company onboarding roles

### DIFF
--- a/Pages/Onboarding.tsx
+++ b/Pages/Onboarding.tsx
@@ -17,6 +17,8 @@ const roleOptions = [
   { id: 'stylist', label: 'Stylist', description: 'Styling, set design en sourcing.' },
   { id: 'makeup_artist', label: 'MUA', description: 'Make-up en hair voor shoots.' },
   { id: 'assistant', label: 'Assistent', description: 'Productie, licht en logistiek.' },
+  { id: 'agency', label: 'Agency', description: 'Representeer talent en coördineer bookings.' },
+  { id: 'company', label: 'Company', description: 'Organiseer producties namens je organisatie.' },
 ];
 
 const startPages = [


### PR DESCRIPTION
## Summary
- add agency and company role options to onboarding selection with labels and descriptions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693083b81bf8832fb2e0d1c9e8fd7c8c)