### PR TITLE
Refine glass theme across pages

### DIFF
--- a/Pages/Analytics.tsx
+++ b/Pages/Analytics.tsx
@@ -14,14 +14,18 @@ type StatCardProps = {
 };
 
 const StatCard = ({ icon: Icon, title, value, note }: StatCardProps) => (
-  <Card className="bg-white/60 backdrop-blur-md shadow-xl rounded-2xl">
-    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-      <CardTitle className="text-sm font-medium text-slate-600">{title}</CardTitle>
-      <Icon className="h-5 w-5 text-slate-500" />
+  <Card className="glass-panel h-full shadow-floating">
+    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+      <CardTitle className="text-sm font-semibold text-midnight-800 dark:text-serenity-50 flex items-center gap-2">
+        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-serenity-200/80 to-serenity-400/80 dark:from-midnight-700/70 dark:to-midnight-500/70 text-midnight-900 dark:text-serenity-50 shadow-soft">
+          <Icon className="h-4 w-4" />
+        </span>
+        {title}
+      </CardTitle>
     </CardHeader>
-    <CardContent>
-      <div className="text-3xl font-bold text-slate-800">{value}</div>
-      {note && <p className="text-xs text-slate-500 mt-1">{note}</p>}
+    <CardContent className="space-y-2">
+      <div className="text-3xl font-bold text-midnight-900 dark:text-white">{value}</div>
+      {note && <p className="text-xs text-slate-700 dark:text-slate-100/80 leading-relaxed">{note}</p>}
     </CardContent>
   </Card>
 );
@@ -81,16 +85,24 @@ export function AnalyticsPage(): JSX.Element {
   if (loading) {
     return (
       <div className="max-w-4xl mx-auto px-4 py-8">
-        <p>Statistieken laden...</p>
+        <div className="glass-panel p-6 shadow-floating">
+          <p className="text-slate-700 dark:text-slate-200">Statistieken laden...</p>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold text-slate-800 mb-8 flex items-center gap-3">
-        <BarChart2 className="w-8 h-8" /> Jouw Statistieken
-      </h1>
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+      <div className="glass-panel p-6 md:p-7 space-y-3 shadow-floating">
+        <p className="text-xs uppercase tracking-[0.25em] text-serenity-700 dark:text-serenity-200">Overzicht</p>
+        <h1 className="text-3xl font-bold text-midnight-900 dark:text-white flex items-center gap-3">
+          <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-gradient-to-br from-serenity-500 to-serenity-400 text-white shadow-floating"><BarChart2 className="w-6 h-6" /></span>
+          Jouw Statistieken
+        </h1>
+        <p className="text-slate-700 dark:text-slate-200">Een serene weergave van je prestaties met zachte blauwe tinten.</p>
+      </div>
+
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         <StatCard
           icon={Users}
@@ -107,15 +119,19 @@ export function AnalyticsPage(): JSX.Element {
           note="Weergave-tracking binnenkort beschikbaar"
         />
       </div>
-      <Card className="mt-8 bg-white/60 backdrop-blur-md shadow-xl rounded-2xl">
+      <Card className="glass-panel shadow-floating">
         <CardHeader>
-          <CardTitle>Binnenkort meer</CardTitle>
+          <CardTitle className="flex items-center gap-2 text-midnight-900 dark:text-white">
+            <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-r from-serenity-400 to-serenity-500 text-white shadow-soft"><Eye className="w-5 h-5" /></span>
+            Binnenkort meer
+          </CardTitle>
         </CardHeader>
-        <CardContent>
-          <p className="text-slate-600">
+        <CardContent className="space-y-2">
+          <p className="text-slate-700 dark:text-slate-200">
             We werken aan gedetailleerde grafieken en analyses om je nog meer inzicht te geven in de
             prestaties van je account.
           </p>
+          <p className="text-sm text-serenity-700 dark:text-serenity-200">Houd deze pagina in de gaten voor nieuwe widgets en interactieve grafieken.</p>
         </CardContent>
       </Card>
     </div>

--- a/Pages/Chat
+++ b/Pages/Chat
@@ -4,18 +4,30 @@ import { MessageSquare } from 'lucide-react';
 
 export default function ChatPage() {
   return (
-    <div className="max-w-xl mx-auto px-4 py-8">
-      <Card className="bg-white/60 backdrop-blur-md shadow-xl rounded-2xl">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <MessageSquare />
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <Card className="glass-panel shadow-floating">
+        <CardHeader className="pb-4">
+          <CardTitle className="flex items-center gap-3 text-midnight-900 dark:text-white">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-serenity-500 to-serenity-400 text-white shadow-floating">
+              <MessageSquare className="w-5 h-5" />
+            </span>
             Chat
           </CardTitle>
         </CardHeader>
-        <CardContent>
-          <div className="text-center py-12">
-            <h3 className="text-lg font-medium text-slate-800">Chatfunctie binnenkort beschikbaar</h3>
-            <p className="text-slate-500 mt-2">Hier kun je binnenkort gesprekken voeren met andere leden van de community.</p>
+        <CardContent className="bg-gradient-to-br from-serenity-50/70 via-white/50 to-serenity-100/40 dark:from-midnight-800/70 dark:via-midnight-700/60 dark:to-midnight-600/60 rounded-2xl border border-white/60 dark:border-midnight-100/30 shadow-inner-soft p-10 text-center space-y-4">
+          <div className="inline-flex items-center gap-2 px-6 py-2.5 rounded-full bg-white/70 dark:bg-midnight-700/70 border border-serenity-200/70 dark:border-midnight-200/50 shadow-soft text-midnight-900 dark:text-serenity-50">
+            <span className="h-2 w-2 rounded-full bg-serenity-500 animate-pulse" />
+            In ontwikkeling
+          </div>
+          <h3 className="text-2xl font-semibold text-midnight-900 dark:text-white">Chatfunctie binnenkort beschikbaar</h3>
+          <p className="text-slate-700 dark:text-slate-200 max-w-2xl mx-auto leading-relaxed">
+            Hier kun je binnenkort gesprekken voeren met andere leden van de community. Het scherm krijgt dezelfde glastint als de rest van Exhibit.
+          </p>
+          <div className="flex justify-center">
+            <div className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-gradient-to-r from-serenity-500 to-serenity-600 text-white shadow-soft">
+              <span className="h-2 w-2 rounded-full bg-white/80 animate-pulse" />
+              Binnenkort live
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/Pages/Community.jsx
+++ b/Pages/Community.jsx
@@ -15,11 +15,11 @@ const communityIcons = {
 };
 
 const communityColors = {
-  safety_consent: "bg-red-100 text-red-800 border-red-200",
-  networking: "bg-blue-100 text-blue-800 border-blue-200",
-  techniques: "bg-purple-100 text-purple-800 border-purple-200",
-  equipment: "bg-green-100 text-green-800 border-green-200",
-  inspiration: "bg-amber-100 text-amber-800 border-amber-200"
+  safety_consent: "from-serenity-100 via-serenity-200 to-serenity-300",
+  networking: "from-sky-100 via-serenity-200 to-sky-200",
+  techniques: "from-serenity-50 via-serenity-100 to-serenity-200",
+  equipment: "from-midnight-100 via-serenity-200 to-serenity-300",
+  inspiration: "from-serenity-200 via-serenity-300 to-serenity-400"
 };
 
 export default function Community() {
@@ -45,23 +45,23 @@ export default function Community() {
   };
 
   return (
-    <div className="max-w-6xl mx-auto px-4 py-2 space-y-6">
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
       {loading ? (
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
           {Array(6).fill(0).map((_, i) => (
-            <Card key={i} className="animate-pulse glass-panel">
+            <Card key={i} className="animate-pulse glass-panel shadow-floating">
               <CardHeader>
-                <div className="bg-serenity-100 h-6 rounded mb-2"></div>
-                <div className="bg-serenity-100 h-4 rounded w-2/3"></div>
+                <div className="bg-serenity-100 dark:bg-midnight-700/70 h-6 rounded mb-2"></div>
+                <div className="bg-serenity-100 dark:bg-midnight-700/70 h-4 rounded w-2/3"></div>
               </CardHeader>
               <CardContent>
-                <div className="bg-serenity-100 h-16 rounded"></div>
+                <div className="bg-serenity-100 dark:bg-midnight-700/70 h-16 rounded"></div>
               </CardContent>
             </Card>
-          ))}
+            ))}
         </div>
       ) : communities.length === 0 ? (
-        <div className="text-center py-16">
+        <div className="text-center py-16 glass-panel shadow-floating">
           {error ? (
             <>
               <Users className="w-16 h-16 mx-auto mb-4 text-serenity-400" />
@@ -70,7 +70,7 @@ export default function Community() {
               <Button
                 variant="outline"
                 onClick={loadCommunities}
-                className="inline-flex items-center gap-2 rounded-full border-serenity-300 text-serenity-800 hover:bg-serenity-100/70 shadow-soft"
+                className="inline-flex items-center gap-2 rounded-full border-serenity-300 text-midnight-900 dark:text-serenity-50 bg-white/60 dark:bg-midnight-700/50 hover:bg-serenity-100/80 shadow-soft px-4 py-2"
               >
                 <RefreshCcw className="w-4 h-4" />
                 Opnieuw proberen
@@ -86,10 +86,10 @@ export default function Community() {
         </div>
       ) : (
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {communities.map((community, index) => {
-            const IconComponent = communityIcons[community.category] || Users;
-            const colorClass = communityColors[community.category] || "bg-gray-100 text-gray-800 border-gray-200";
-            
+            {communities.map((community, index) => {
+              const IconComponent = communityIcons[community.category] || Users;
+            const gradient = communityColors[community.category] || "from-serenity-100 via-serenity-200 to-serenity-300";
+
             return (
               <motion.div
                 key={community.id}
@@ -98,26 +98,26 @@ export default function Community() {
                 transition={{ delay: index * 0.1 }}
               >
                 <Card className="hover:shadow-floating transition-all duration-300 glass-panel h-full">
-                  <CardHeader>
+                  <CardHeader className="pb-2">
                     <div className="flex items-start justify-between">
                       <div className="flex items-center space-x-3">
-                        <div className={`p-2 rounded-lg ${colorClass} border`}>
+                        <div className={`p-3 rounded-full bg-gradient-to-r ${gradient} text-midnight-900 dark:text-serenity-50 border border-serenity-200/70 dark:border-midnight-200/50 shadow-soft`}>
                           <IconComponent className="w-5 h-5" />
                         </div>
                         <div>
                           <CardTitle className="text-lg text-midnight-900 dark:text-white">{community.name}</CardTitle>
-                          <Badge variant="outline" className={`mt-1 ${colorClass} border text-xs`}>
+                          <Badge variant="outline" className={`mt-2 bg-gradient-to-r ${gradient} border-serenity-200/70 dark:border-midnight-200/50 text-xs text-midnight-900 dark:text-serenity-50 rounded-full px-3 py-1`}>
                             {community.member_count} leden
                           </Badge>
                         </div>
                       </div>
                     </div>
                   </CardHeader>
-                  <CardContent className="pt-0">
-                    <p className="text-slate-700 dark:text-slate-200 text-sm leading-relaxed mb-4">
+                  <CardContent className="pt-1 space-y-4">
+                    <p className="text-slate-700 dark:text-slate-200 text-sm leading-relaxed">
                       {community.description}
                     </p>
-                    <Button variant="outline" className="w-full rounded-full border-serenity-300 text-serenity-800 hover:bg-serenity-100/70 shadow-soft">
+                    <Button variant="outline" className="w-full rounded-full border-serenity-300/80 dark:border-midnight-200/60 text-midnight-900 dark:text-serenity-50 bg-white/60 dark:bg-midnight-700/50 hover:bg-serenity-100/70 shadow-soft px-4 py-2.5">
                       Bekijk community
                     </Button>
                   </CardContent>

--- a/Pages/Discover.jsx
+++ b/Pages/Discover.jsx
@@ -97,44 +97,44 @@ const PeopleTab = ({ searchTerm }) => {
   }, [users, activeRole, searchTerm]);
 
   return (
-    <div className="px-4">
+    <div className="px-4 sm:px-6 space-y-6">
       {/* Role Filter Pills */}
-      <div className="flex space-x-2 mb-6 overflow-x-auto pb-2">
+      <div className="flex space-x-3 mb-2 overflow-x-auto pb-3 no-scrollbar">
         {userRoles.map(role => (
           <Button
             key={role.id}
-            variant={activeRole === role.id ? 'default' : 'outline'}
+            variant="outline"
             onClick={() => setActiveRole(role.id)}
-            className={`shrink-0 ${
+            className={`shrink-0 rounded-full px-5 py-2.5 text-sm font-semibold border-serenity-200/70 dark:border-midnight-200/50 shadow-soft transition-all ${
               activeRole === role.id
-                ? 'bg-serenity-600 text-white shadow-soft'
-                : 'bg-white/80 text-midnight-900 dark:text-serenity-50 border-serenity-200/70'
-            } rounded-full px-4 py-2`}
+                ? 'bg-gradient-to-r from-serenity-600 to-serenity-500 text-white'
+                : 'bg-white/70 dark:bg-midnight-700/60 text-midnight-900 dark:text-serenity-50 hover:bg-serenity-100/60'
+            }`}
           >
             {role.label}
           </Button>
         ))}
       </div>
-      
+
       {/* Users Grid */}
       {loading ? (
-        <p className="text-center text-slate-600">Gebruikers laden...</p>
+        <div className="glass-panel p-6 text-center shadow-floating">
+          <p className="text-slate-600 dark:text-slate-200">Gebruikers laden...</p>
+        </div>
       ) : (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-5">
           {filteredUsers.map(user => (
             <motion.div key={user.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-              <Card className="text-center glass-panel overflow-hidden hover:shadow-floating transition-all flex flex-col bg-white/80 dark:bg-midnight-900/80">
+              <Card className="text-center glass-panel overflow-hidden hover:shadow-floating transition-all flex flex-col">
                 <Avatar className="w-full h-32 sm:h-40 rounded-none shrink-0">
                   <AvatarImage src={user.avatar_url} className="object-cover" />
                   <AvatarFallback className="rounded-none">
                     {user.display_name?.[0] || <UserIcon className="w-8 h-8" />}
                   </AvatarFallback>
                 </Avatar>
-                <CardContent className="p-3 bg-white/90 dark:bg-midnight-950/80 text-midnight-900 dark:text-serenity-50">
+                <CardContent className="p-4 pb-2 text-midnight-900 dark:text-serenity-50">
                   <h4 className="font-semibold truncate">{user.display_name || "Gebruiker"}</h4>
-                </CardContent>
-                <CardContent className="pt-0 pb-3 px-3 bg-white/95 dark:bg-midnight-950/80 text-midnight-800 dark:text-slate-200 overflow-hidden">
-                  <p className="text-xs truncate">{user.roles?.join(', ') || "Creatief"}</p>
+                  <p className="text-xs truncate text-slate-600 dark:text-slate-200 mt-1">{user.roles?.join(', ') || "Creatief"}</p>
                 </CardContent>
               </Card>
             </motion.div>
@@ -184,16 +184,16 @@ const StylesTab = ({ searchTerm }) => {
   const visibleStyles = showAllStyles ? photographyStyles : photographyStyles.slice(0, 5);
 
   return (
-    <div className="px-4">
+    <div className="px-4 sm:px-6 space-y-6">
       {/* Style Filter Pills */}
-      <div className="flex flex-wrap gap-3 mb-6 overflow-x-auto pb-2">
+      <div className="flex flex-wrap gap-3 mb-2 overflow-x-auto pb-3 no-scrollbar">
         <Button
-          variant={!selectedStyle ? 'default' : 'outline'}
+          variant="outline"
           onClick={() => setSelectedStyle(null)}
-          className={`rounded-full px-4 py-2 shrink-0 ${
+          className={`rounded-full px-5 py-2.5 shrink-0 font-semibold border-serenity-200/70 dark:border-midnight-200/50 shadow-soft ${
             !selectedStyle
-              ? 'bg-serenity-600 text-white shadow-soft'
-              : 'bg-white/80 text-midnight-900 dark:text-serenity-50 border-serenity-200/70'
+              ? 'bg-gradient-to-r from-serenity-600 to-serenity-500 text-white'
+              : 'bg-white/70 dark:bg-midnight-700/60 text-midnight-900 dark:text-serenity-50 hover:bg-serenity-100/60'
           }`}
         >
           Alles
@@ -203,7 +203,7 @@ const StylesTab = ({ searchTerm }) => {
             key={style.id}
             type="button"
             onClick={() => setSelectedStyle(style.id)}
-            className={`shrink-0 flex items-center gap-2 px-4 py-2 text-sm font-semibold ${getStylePillClasses(style.id, {
+            className={`shrink-0 flex items-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-full border border-serenity-200/70 dark:border-midnight-200/40 shadow-soft ${getStylePillClasses(style.id, {
               active: selectedStyle === style.id,
             })}`}
           >
@@ -215,7 +215,7 @@ const StylesTab = ({ searchTerm }) => {
           <Button
             variant="outline"
             onClick={() => setShowAllStyles(true)}
-            className="rounded-full bg-white/80 text-serenity-700 border-serenity-300 hover:bg-serenity-100 shadow-soft"
+            className="rounded-full px-5 py-2.5 bg-white/70 dark:bg-midnight-700/60 text-midnight-900 dark:text-serenity-50 border-serenity-300/80 dark:border-midnight-200/60 hover:bg-serenity-100 shadow-soft"
           >
             Toon meer...
           </Button>
@@ -224,7 +224,7 @@ const StylesTab = ({ searchTerm }) => {
       
       {/* Posts Grid */}
       {loading ? (
-        <p className="text-center text-slate-600">Posts laden...</p>
+        <p className="text-center text-slate-600 dark:text-slate-200">Posts laden...</p>
       ) : (
         <div className="space-y-6">
           {filteredPosts.map((post) => (
@@ -240,17 +240,17 @@ export default function Discover() {
   const [searchTerm, setSearchTerm] = useState("");
 
   return (
-    <div className="max-w-6xl mx-auto px-3 pt-4 space-y-6">
+    <div className="max-w-6xl mx-auto px-3 pt-6 space-y-8">
       {/* Search Bar - direct starten */}
       <div className="relative px-4">
-        <div className="glass-panel rounded-2xl shadow-floating p-1">
+        <div className="glass-panel rounded-full shadow-floating p-1.5">
           <div className="relative">
-            <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-serenity-500 dark:text-serenity-200 w-5 h-5" />
+            <Search className="absolute left-5 top-1/2 transform -translate-y-1/2 text-serenity-600 dark:text-serenity-200 w-5 h-5" />
             <Input
               placeholder="Zoek naar mensen, stijlen, of titels..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="pl-11 pr-4 py-3 text-lg bg-transparent border-none focus-visible:ring-0"
+              className="pl-12 pr-5 py-3 text-lg bg-transparent border-none focus-visible:ring-0"
             />
           </div>
         </div>
@@ -258,12 +258,12 @@ export default function Discover() {
 
       {/* Tabs */}
       <Tabs defaultValue="people" className="w-full">
-        <TabsList className="grid w-full grid-cols-2 mb-6 bg-white/70 dark:bg-midnight-100/60 backdrop-blur-sm rounded-2xl mx-4 border border-serenity-200/70 dark:border-midnight-50/30 shadow-soft">
-          <TabsTrigger value="people" className="flex items-center space-x-2 data-[state=active]:bg-serenity-600 data-[state=active]:text-white rounded-xl">
+        <TabsList className="grid w-full grid-cols-2 mb-6 bg-white/60 dark:bg-midnight-800/50 backdrop-blur-lg rounded-full mx-4 border border-serenity-200/60 dark:border-midnight-200/50 shadow-floating p-1">
+          <TabsTrigger value="people" className="flex items-center justify-center gap-2 data-[state=active]:bg-gradient-to-r data-[state=active]:from-serenity-600 data-[state=active]:to-serenity-500 data-[state=active]:text-white rounded-full py-3 px-4 text-midnight-800 dark:text-serenity-100">
             <UserIcon className="w-4 h-4" />
             <span>Mensen</span>
           </TabsTrigger>
-          <TabsTrigger value="styles" className="flex items-center space-x-2 data-[state=active]:bg-serenity-600 data-[state=active]:text-white rounded-xl">
+          <TabsTrigger value="styles" className="flex items-center justify-center gap-2 data-[state=active]:bg-gradient-to-r data-[state=active]:from-serenity-600 data-[state=active]:to-serenity-500 data-[state=active]:text-white rounded-full py-3 px-4 text-midnight-800 dark:text-serenity-100">
             <Palette className="w-4 h-4" />
             <span>Stijlen</span>
           </TabsTrigger>

--- a/Pages/IDVerfication
+++ b/Pages/IDVerfication
@@ -5,30 +5,32 @@ import { ShieldCheck } from 'lucide-react';
 
 export default function IDVerificationPage() {
     return (
-        <div className="max-w-xl mx-auto px-4 py-8">
-            <Card className="bg-white/60 backdrop-blur-md shadow-xl rounded-2xl">
+        <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+            <Card className="glass-panel shadow-floating">
                 <CardHeader>
-                    <CardTitle className="flex items-center gap-3">
-                        <ShieldCheck className="w-6 h-6 text-blue-600"/>
+                    <CardTitle className="flex items-center gap-3 text-midnight-900 dark:text-white">
+                        <span className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-gradient-to-br from-serenity-500 to-serenity-400 text-white shadow-floating">
+                            <ShieldCheck className="w-6 h-6"/>
+                        </span>
                         Verifieer je leeftijd (18+)
                     </CardTitle>
                 </CardHeader>
-                <CardContent className="space-y-4">
-                    <p className="text-slate-600">
+                <CardContent className="space-y-5">
+                    <p className="text-slate-700 dark:text-slate-200 leading-relaxed">
                         Om de veiligheid van onze community te waarborgen en te voldoen aan de richtlijnen,
                         vragen we leden die gevoelige content willen bekijken of plaatsen om hun leeftijd te verifiëren.
                     </p>
-                    <div className="bg-blue-50 border-l-4 border-blue-400 p-4 rounded-r-lg">
-                        <h4 className="font-semibold text-blue-900">Hoe werkt het?</h4>
-                        <p className="text-sm text-blue-800 mt-2">
+                    <div className="rounded-2xl bg-gradient-to-r from-serenity-100/80 via-serenity-200/80 to-serenity-300/70 dark:from-midnight-800/70 dark:via-midnight-700/70 dark:to-midnight-600/70 border border-serenity-200/70 dark:border-midnight-200/50 p-5 shadow-soft">
+                        <h4 className="font-semibold text-midnight-900 dark:text-white">Hoe werkt het?</h4>
+                        <p className="text-sm text-midnight-800 dark:text-slate-200 mt-2 leading-relaxed">
                             We werken aan een integratie met een veilige, externe verificatiedienst zoals iDIN.
                             Dit proces is volledig geautomatiseerd en je gegevens worden niet door ons opgeslagen.
                         </p>
                     </div>
-                    <p className="text-slate-600">
+                    <p className="text-slate-700 dark:text-slate-200">
                         Deze functie is binnenkort beschikbaar.
                     </p>
-                    <Button disabled className="w-full">
+                    <Button disabled className="w-full rounded-full bg-gradient-to-r from-serenity-500 to-serenity-600 text-white shadow-soft py-3">
                         Start Verificatie (Binnenkort)
                     </Button>
                 </CardContent>

--- a/Pages/Profile.jsx
+++ b/Pages/Profile.jsx
@@ -126,7 +126,18 @@ const EditProfileDialog = ({ open, onOpenChange, user, onProfileUpdate }) => {
               <Label>Rollen</Label>
               <div className="mt-2 flex flex-wrap gap-2">
                 {userRoles.map(role => (
-                  <Badge key={role.id} onClick={() => toggleBadge('roles', role.id)} variant={editData.roles?.includes(role.id) ? 'default' : 'outline'} className="cursor-pointer transition-all hover:bg-slate-100 py-1 px-3 text-sm">{role.label}</Badge>
+                  <Badge
+                    key={role.id}
+                    onClick={() => toggleBadge('roles', role.id)}
+                    variant={editData.roles?.includes(role.id) ? 'default' : 'outline'}
+                    className={`cursor-pointer transition-all rounded-full px-4 py-1.5 text-sm border-serenity-200/70 dark:border-midnight-200/60 ${
+                      editData.roles?.includes(role.id)
+                        ? 'bg-gradient-to-r from-serenity-500 to-serenity-600 text-white shadow-soft'
+                        : 'bg-white/70 dark:bg-midnight-800/70 text-midnight-900 dark:text-serenity-50 hover:bg-serenity-100/70'
+                    }`}
+                  >
+                    {role.label}
+                  </Badge>
                 ))}
               </div>
             </div>
@@ -134,7 +145,18 @@ const EditProfileDialog = ({ open, onOpenChange, user, onProfileUpdate }) => {
               <Label>Stijlen</Label>
               <div className="mt-2 flex flex-wrap gap-2">
                 {photographyStyles.map(style => (
-                  <Badge key={style.id} onClick={() => toggleBadge('styles', style.id)} variant={editData.styles?.includes(style.id) ? 'default' : 'outline'} className="cursor-pointer transition-all hover:bg-slate-100 py-1 px-3 text-sm">{style.label}</Badge>
+                  <Badge
+                    key={style.id}
+                    onClick={() => toggleBadge('styles', style.id)}
+                    variant={editData.styles?.includes(style.id) ? 'default' : 'outline'}
+                    className={`cursor-pointer transition-all rounded-full px-4 py-1.5 text-sm border-serenity-200/70 dark:border-midnight-200/60 ${
+                      editData.styles?.includes(style.id)
+                        ? 'bg-gradient-to-r from-serenity-500 to-serenity-600 text-white shadow-soft'
+                        : 'bg-white/70 dark:bg-midnight-800/70 text-midnight-900 dark:text-serenity-50 hover:bg-serenity-100/70'
+                    }`}
+                  >
+                    {style.label}
+                  </Badge>
                 ))}
               </div>
             </div>
@@ -150,8 +172,12 @@ const EditProfileDialog = ({ open, onOpenChange, user, onProfileUpdate }) => {
           </div>
 
           <div className="flex justify-end space-x-3 pt-4 border-t">
-            <Button variant="outline" onClick={() => onOpenChange(false)}>Annuleren</Button>
-            <Button onClick={handleSaveProfile} className="bg-blue-800 hover:bg-blue-900">Profiel Opslaan</Button>
+            <Button variant="outline" onClick={() => onOpenChange(false)} className="rounded-full px-5 py-2.5 border-serenity-200/80 dark:border-midnight-200/60">
+              Annuleren
+            </Button>
+            <Button onClick={handleSaveProfile} className="rounded-full px-5 py-2.5 bg-gradient-to-r from-serenity-600 to-serenity-500 text-white shadow-soft">
+              Profiel Opslaan
+            </Button>
           </div>
         </div>
       </DialogContent>
@@ -281,11 +307,11 @@ export default function Profile() {
     return (
       <div className="max-w-4xl mx-auto px-4">
         <div className="animate-pulse space-y-8">
-          <div className="bg-serenity-100/70 h-40 rounded-2xl shadow-soft"></div>
-          <div className="bg-serenity-100/70 h-12 rounded-2xl shadow-soft"></div>
+          <div className="bg-serenity-100/70 dark:bg-midnight-700/60 h-40 rounded-2xl shadow-soft"></div>
+          <div className="bg-serenity-100/70 dark:bg-midnight-700/60 h-12 rounded-2xl shadow-soft"></div>
           <div className="grid grid-cols-3 gap-4">
             {Array(6).fill(0).map((_, i) => (
-              <div key={i} className="bg-serenity-100/70 aspect-square rounded-2xl shadow-soft"></div>
+              <div key={i} className="bg-serenity-100/70 dark:bg-midnight-700/60 aspect-square rounded-2xl shadow-soft"></div>
             ))}
           </div>
         </div>
@@ -308,21 +334,21 @@ export default function Profile() {
               <AvatarImage src={user.avatar_url} />
               <AvatarFallback>{user.display_name?.[0]}</AvatarFallback>
             </Avatar>
-            <div className="flex-1 text-center md:text-left">
-              <h1 className="text-3xl font-bold text-midnight-900 dark:text-white">{user.display_name || user.full_name}</h1>
-              <p className="text-slate-700 dark:text-slate-200 mt-2">{user.bio || "Deel je verhaal en inspireer anderen..."}</p>
-              <div className="flex flex-wrap gap-2 mt-4 justify-center md:justify-start">
-                {user.roles?.map(roleId => {
-                    const roleInfo = userRoles.find(r => r.id === roleId);
-                    return <Badge key={roleId} variant="secondary" className="bg-serenity-100 text-serenity-800 border-serenity-200">{roleInfo?.label}</Badge>
-                })}
-                {user.styles?.slice(0, 3).map(styleId => {
-                    const styleInfo = photographyStyles.find(s => s.id === styleId);
-                    return <Badge key={styleId} variant="outline" className="border-serenity-300 text-serenity-800 dark:text-serenity-100">{styleInfo?.label}</Badge>
-                })}
+              <div className="flex-1 text-center md:text-left">
+                <h1 className="text-3xl font-bold text-midnight-900 dark:text-white">{user.display_name || user.full_name}</h1>
+                <p className="text-slate-700 dark:text-slate-200 mt-2">{user.bio || "Deel je verhaal en inspireer anderen..."}</p>
+                <div className="flex flex-wrap gap-2 mt-4 justify-center md:justify-start">
+                  {user.roles?.map(roleId => {
+                      const roleInfo = userRoles.find(r => r.id === roleId);
+                      return <Badge key={roleId} variant="secondary" className="rounded-full px-4 py-1.5 bg-gradient-to-r from-serenity-200 to-serenity-300 text-midnight-900 border-serenity-200/70 shadow-soft">{roleInfo?.label}</Badge>
+                  })}
+                  {user.styles?.slice(0, 3).map(styleId => {
+                      const styleInfo = photographyStyles.find(s => s.id === styleId);
+                      return <Badge key={styleId} variant="outline" className="rounded-full px-4 py-1.5 border-serenity-300/80 dark:border-midnight-200/60 text-midnight-900 dark:text-serenity-50 bg-white/70 dark:bg-midnight-800/70">{styleInfo?.label}</Badge>
+                  })}
+                </div>
               </div>
             </div>
-          </div>
         </CardContent>
       </Card>
 
@@ -337,25 +363,25 @@ export default function Profile() {
               <div className="text-2xl font-bold text-midnight-900 dark:text-white">{savedPosts.length}</div>
               <div className="text-sm text-slate-600 dark:text-slate-300 uppercase">Opgeslagen</div>
             </div>
-            <div className="flex items-center space-x-2">
-                <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" onClick={() => setShowEditProfile(true)} title="Profiel bewerken"><Edit className="w-5 h-5" /></Button>
-                <Link to={createPageUrl("Analytics")}>
-                  <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" title="Statistieken"><BarChart2 className="w-5 h-5" /></Button>
-                </Link>
-                <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" onClick={toggleSensitiveContent} title={user.show_sensitive_content ? "Gevoelige content verbergen" : "Gevoelige content tonen"}>
-                  {user.show_sensitive_content ? <Eye className="w-5 h-5" /> : <EyeOff className="w-5 h-5" />}
-                </Button>
-                <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" onClick={() => setShowHouseRules(true)} title="Huisregels"><Shield className="w-5 h-5" /></Button>
-                <Button variant="ghost" size="icon" className="rounded-full bg-serenity-100 dark:bg-midnight-100/40" onClick={handleLogout} title="Uitloggen"><LogOut className="w-5 h-5 text-red-500" /></Button>
-            </div>
-        </CardContent>
-      </Card>
+              <div className="flex items-center space-x-2">
+                  <Button variant="ghost" size="icon" className="rounded-full bg-white/70 dark:bg-midnight-700/60 border border-serenity-200/70 dark:border-midnight-200/50 text-midnight-900 dark:text-serenity-50 shadow-soft" onClick={() => setShowEditProfile(true)} title="Profiel bewerken"><Edit className="w-5 h-5" /></Button>
+                  <Link to={createPageUrl("Analytics")}>
+                    <Button variant="ghost" size="icon" className="rounded-full bg-white/70 dark:bg-midnight-700/60 border border-serenity-200/70 dark:border-midnight-200/50 text-midnight-900 dark:text-serenity-50 shadow-soft" title="Statistieken"><BarChart2 className="w-5 h-5" /></Button>
+                  </Link>
+                  <Button variant="ghost" size="icon" className="rounded-full bg-white/70 dark:bg-midnight-700/60 border border-serenity-200/70 dark:border-midnight-200/50 text-midnight-900 dark:text-serenity-50 shadow-soft" onClick={toggleSensitiveContent} title={user.show_sensitive_content ? "Gevoelige content verbergen" : "Gevoelige content tonen"}>
+                    {user.show_sensitive_content ? <Eye className="w-5 h-5" /> : <EyeOff className="w-5 h-5" />}
+                  </Button>
+                  <Button variant="ghost" size="icon" className="rounded-full bg-white/70 dark:bg-midnight-700/60 border border-serenity-200/70 dark:border-midnight-200/50 text-midnight-900 dark:text-serenity-50 shadow-soft" onClick={() => setShowHouseRules(true)} title="Huisregels"><Shield className="w-5 h-5" /></Button>
+                  <Button variant="ghost" size="icon" className="rounded-full bg-white/70 dark:bg-midnight-700/60 border border-serenity-200/70 dark:border-midnight-200/50 text-midnight-900 dark:text-serenity-50 shadow-soft" onClick={handleLogout} title="Uitloggen"><LogOut className="w-5 h-5" /></Button>
+              </div>
+          </CardContent>
+        </Card>
       
       {/* Content Tabs */}
         <Tabs defaultValue="posts" className="w-full">
-          <TabsList className="grid w-full grid-cols-2 mb-6 bg-white/70 dark:bg-midnight-100/60 backdrop-blur-sm rounded-2xl border border-serenity-200/70 dark:border-midnight-50/30 shadow-soft">
-            <TabsTrigger value="posts" className="flex items-center space-x-2 data-[state=active]:bg-serenity-600 data-[state=active]:text-white rounded-xl"><Grid className="w-4 h-4" /><span>Mijn Posts</span></TabsTrigger>
-            <TabsTrigger value="saved" className="flex items-center space-x-2 data-[state=active]:bg-serenity-600 data-[state=active]:text-white rounded-xl"><Bookmark className="w-4 h-4" /><span>Moodboard</span></TabsTrigger>
+          <TabsList className="grid w-full grid-cols-2 mb-6 bg-white/60 dark:bg-midnight-800/50 backdrop-blur-lg rounded-full border border-serenity-200/60 dark:border-midnight-200/50 shadow-floating p-1">
+            <TabsTrigger value="posts" className="flex items-center justify-center gap-2 data-[state=active]:bg-gradient-to-r data-[state=active]:from-serenity-600 data-[state=active]:to-serenity-500 data-[state=active]:text-white rounded-full py-3 px-4 text-midnight-800 dark:text-serenity-100"><Grid className="w-4 h-4" /><span>Mijn Posts</span></TabsTrigger>
+            <TabsTrigger value="saved" className="flex items-center justify-center gap-2 data-[state=active]:bg-gradient-to-r data-[state=active]:from-serenity-600 data-[state=active]:to-serenity-500 data-[state=active]:text-white rounded-full py-3 px-4 text-midnight-800 dark:text-serenity-100"><Bookmark className="w-4 h-4" /><span>Moodboard</span></TabsTrigger>
           </TabsList>
 
         <TabsContent value="posts">

--- a/Pages/Timeline.tsx
+++ b/Pages/Timeline.tsx
@@ -54,8 +54,8 @@ export default function Timeline() {
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-6 pb-32 space-y-6">
-      <div className="space-y-3 glass-panel p-5">
-        <p className="text-xs uppercase tracking-[0.2em] text-serenity-600 font-semibold">Exhibit</p>
+      <div className="space-y-3 glass-panel p-6 shadow-floating">
+        <p className="text-xs uppercase tracking-[0.2em] text-serenity-700 dark:text-serenity-200 font-semibold">Exhibit</p>
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-2">
             <h1 className="text-3xl font-bold text-midnight-900 dark:text-white">Tijdlijn</h1>
@@ -67,7 +67,10 @@ export default function Timeline() {
       {loading ? (
         <div className="space-y-4">
           {[...Array(3)].map((_, index) => (
-            <div key={index} className="h-80 rounded-2xl bg-gradient-to-r from-slate-100 to-slate-200 animate-pulse" />
+            <div
+              key={index}
+              className="h-80 rounded-3xl bg-gradient-to-r from-serenity-50 via-serenity-100 to-serenity-200 dark:from-midnight-700/60 dark:via-midnight-600/60 dark:to-midnight-500/60 animate-pulse shadow-soft"
+            />
           ))}
         </div>
       ) : posts.length === 0 ? (

--- a/src/index.css
+++ b/src/index.css
@@ -40,10 +40,10 @@
 
 @layer components {
   .glass-panel {
-    @apply bg-white/70 dark:bg-midnight-100/60 backdrop-blur-lg border border-serenity-200/70 dark:border-midnight-50/30 shadow-soft rounded-2xl;
+    @apply bg-gradient-to-br from-white/75 via-serenity-50/70 to-serenity-100/60 dark:from-midnight-800/70 dark:via-midnight-700/60 dark:to-midnight-800/70 backdrop-blur-xl border border-serenity-200/60 dark:border-midnight-100/40 shadow-floating rounded-3xl;
   }
 
   .pill-button {
-    @apply inline-flex items-center gap-2 rounded-full px-4 py-2 font-medium transition-all duration-200 shadow-soft bg-serenity-500 text-white hover:bg-serenity-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-serenity-300 dark:focus-visible:ring-midnight-50/50;
+    @apply inline-flex items-center gap-2 rounded-full px-5 py-2.5 font-semibold transition-all duration-200 shadow-soft bg-gradient-to-r from-serenity-600 to-serenity-500 text-white hover:from-serenity-700 hover:to-serenity-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-serenity-300 dark:focus-visible:ring-midnight-50/50;
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,8 @@ import AnalyticsPage from '../Pages/Analytics';
 import CommunityPage from '../Pages/Community.jsx';
 import ProfilePage from '../Pages/Profile.jsx';
 import SearchPage from '../Pages/Discover.jsx';
+import ChatPage from '../Pages/Chat';
+import IDVerificationPage from '../Pages/IDVerfication';
 import TimelinePage from '../Pages/Timeline';
 import { PAGE_ROUTES } from '@/utils';
 import { ThemeProvider } from '@/context/ThemeContext';
@@ -51,6 +53,8 @@ function App() {
           <Route path={PAGE_ROUTES.discover} element={renderPage('Discover', <SearchPage />)} />
           <Route path={PAGE_ROUTES.profile} element={renderPage('Profile', <ProfilePage />)} />
           <Route path={PAGE_ROUTES.analytics} element={renderPage('Analytics', <AnalyticsPage />)} />
+          <Route path={PAGE_ROUTES.chat} element={renderPage('Chat', <ChatPage />)} />
+          <Route path={PAGE_ROUTES.idVerification} element={renderPage('IDVerification', <IDVerificationPage />)} />
         </Routes>
       </BrowserRouter>
     </ThemeProvider>

--- a/utils/photographyStyles.js
+++ b/utils/photographyStyles.js
@@ -38,18 +38,18 @@ export const photographyStyles = [
 ];
 
 const colorPalette = [
-  { gradient: 'from-rose-50 via-rose-100 to-rose-200', text: 'text-rose-900', border: 'border-rose-100', ring: 'ring-rose-200/70' },
-  { gradient: 'from-sky-50 via-sky-100 to-sky-200', text: 'text-sky-900', border: 'border-sky-100', ring: 'ring-sky-200/70' },
-  { gradient: 'from-amber-50 via-amber-100 to-amber-200', text: 'text-amber-900', border: 'border-amber-100', ring: 'ring-amber-200/70' },
-  { gradient: 'from-emerald-50 via-emerald-100 to-emerald-200', text: 'text-emerald-900', border: 'border-emerald-100', ring: 'ring-emerald-200/70' },
-  { gradient: 'from-indigo-50 via-indigo-100 to-indigo-200', text: 'text-indigo-900', border: 'border-indigo-100', ring: 'ring-indigo-200/70' },
-  { gradient: 'from-purple-50 via-purple-100 to-purple-200', text: 'text-purple-900', border: 'border-purple-100', ring: 'ring-purple-200/70' },
-  { gradient: 'from-teal-50 via-teal-100 to-teal-200', text: 'text-teal-900', border: 'border-teal-100', ring: 'ring-teal-200/70' },
-  { gradient: 'from-blue-50 via-blue-100 to-blue-200', text: 'text-blue-900', border: 'border-blue-100', ring: 'ring-blue-200/70' },
-  { gradient: 'from-orange-50 via-orange-100 to-orange-200', text: 'text-orange-900', border: 'border-orange-100', ring: 'ring-orange-200/70' },
-  { gradient: 'from-lime-50 via-lime-100 to-lime-200', text: 'text-lime-900', border: 'border-lime-100', ring: 'ring-lime-200/70' },
-  { gradient: 'from-pink-50 via-pink-100 to-pink-200', text: 'text-pink-900', border: 'border-pink-100', ring: 'ring-pink-200/70' },
-  { gradient: 'from-slate-50 via-slate-100 to-slate-200', text: 'text-slate-900', border: 'border-slate-100', ring: 'ring-slate-200/70' },
+  { gradient: 'from-white via-serenity-50 to-serenity-100', text: 'text-midnight-900', border: 'border-serenity-100', ring: 'ring-serenity-200/70' },
+  { gradient: 'from-serenity-50 via-serenity-100 to-serenity-200', text: 'text-midnight-900', border: 'border-serenity-100/80', ring: 'ring-serenity-200/70' },
+  { gradient: 'from-sky-50 via-sky-100 to-sky-200', text: 'text-midnight-900', border: 'border-sky-100', ring: 'ring-sky-200/70' },
+  { gradient: 'from-serenity-100 via-serenity-200 to-serenity-300', text: 'text-midnight-900', border: 'border-serenity-200', ring: 'ring-serenity-300/60' },
+  { gradient: 'from-slate-50 via-serenity-50 to-slate-200', text: 'text-midnight-900', border: 'border-serenity-100', ring: 'ring-serenity-200/60' },
+  { gradient: 'from-sky-100 via-serenity-200 to-sky-300', text: 'text-midnight-900', border: 'border-sky-100', ring: 'ring-serenity-300/60' },
+  { gradient: 'from-white/90 via-slate-100 to-serenity-100', text: 'text-midnight-900', border: 'border-serenity-100/80', ring: 'ring-serenity-200/60' },
+  { gradient: 'from-midnight-900/20 via-midnight-800/10 to-serenity-200/80', text: 'text-midnight-900', border: 'border-midnight-100/40', ring: 'ring-serenity-300/70' },
+  { gradient: 'from-midnight-800/40 via-midnight-700/40 to-serenity-300/80', text: 'text-serenity-50', border: 'border-midnight-200/50', ring: 'ring-serenity-400/70' },
+  { gradient: 'from-serenity-200 via-serenity-300 to-serenity-400', text: 'text-midnight-900', border: 'border-serenity-300', ring: 'ring-serenity-400/60' },
+  { gradient: 'from-sky-200 via-serenity-200 to-serenity-300', text: 'text-midnight-900', border: 'border-serenity-200', ring: 'ring-serenity-300/60' },
+  { gradient: 'from-serenity-50 via-white to-serenity-100', text: 'text-midnight-900', border: 'border-serenity-100', ring: 'ring-serenity-200/70' },
 ];
 
 const styleColorMap = {


### PR DESCRIPTION
## Summary
- deepen the glassy blue styling on Analytics, Chat, Community, Discover, ID verification, Profile loading, and Timeline to keep controls and skeletons readable in light and dark modes
- add router entries for the Chat and ID verification screens while giving stat cards and empty states a consistent floating glass treatment

## Testing
- npm run lint (warns about an existing unused variable in Components/PostCard.jsx)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7e36a5ac832faaf0332e1457c78c)