### PR TITLE
Add profile links to discover user cards

### DIFF
--- a/Pages/Discover.jsx
+++ b/Pages/Discover.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { Post } from "../entities/Post.js";
 import { User } from "../entities/User.js";
+import { Link } from "react-router-dom";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Search, User as UserIcon, Palette } from "lucide-react";
@@ -125,20 +126,26 @@ const PeopleTab = ({ searchTerm }) => {
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
           {filteredUsers.map(user => (
             <motion.div key={user.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-              <Card className="text-center glass-panel overflow-hidden hover:shadow-floating transition-all flex flex-col bg-white/80 dark:bg-midnight-900/80">
-                <Avatar className="w-full h-32 sm:h-40 rounded-none shrink-0">
-                  <AvatarImage src={user.avatar_url} className="object-cover" />
-                  <AvatarFallback className="rounded-none">
-                    {user.display_name?.[0] || <UserIcon className="w-8 h-8" />}
-                  </AvatarFallback>
-                </Avatar>
-                <CardContent className="p-3 bg-white/90 dark:bg-midnight-950/80 text-midnight-900 dark:text-serenity-50">
-                  <h4 className="font-semibold truncate">{user.display_name || "Gebruiker"}</h4>
-                </CardContent>
-                <CardContent className="pt-0 pb-3 px-3 bg-white/95 dark:bg-midnight-950/80 text-midnight-800 dark:text-slate-200 overflow-hidden">
-                  <p className="text-xs truncate">{user.roles?.join(', ') || "Creatief"}</p>
-                </CardContent>
-              </Card>
+              <Link
+                to={`/profile/${user.id}`}
+                aria-label={`Bekijk profiel van ${user.display_name || 'de gebruiker'}`}
+                className="block group focus:outline-none focus-visible:ring-2 focus-visible:ring-serenity-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-midnight-900 rounded-xl"
+              >
+                <Card className="text-center glass-panel overflow-hidden group-hover:shadow-floating hover:shadow-floating transition-all flex flex-col bg-white/80 dark:bg-midnight-900/80 rounded-xl">
+                  <Avatar className="w-full h-32 sm:h-40 rounded-none shrink-0">
+                    <AvatarImage src={user.avatar_url} className="object-cover" />
+                    <AvatarFallback className="rounded-none">
+                      {user.display_name?.[0] || <UserIcon className="w-8 h-8" />}
+                    </AvatarFallback>
+                  </Avatar>
+                  <CardContent className="p-3 bg-white/90 dark:bg-midnight-950/80 text-midnight-900 dark:text-serenity-50">
+                    <h4 className="font-semibold truncate">{user.display_name || "Gebruiker"}</h4>
+                  </CardContent>
+                  <CardContent className="pt-0 pb-3 px-3 bg-white/95 dark:bg-midnight-950/80 text-midnight-800 dark:text-slate-200 overflow-hidden">
+                    <p className="text-xs truncate">{user.roles?.join(', ') || "Creatief"}</p>
+                  </CardContent>
+                </Card>
+              </Link>
             </motion.div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- wrap discover user cards in links to each profile with accessible labels
- keep existing hover styling while making the cards fully clickable

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930c115ed90832fa981307536ace1b3)