### PR TITLE
Improve Discover tab styling

### DIFF
--- a/Pages/Discover.jsx
+++ b/Pages/Discover.jsx
@@ -235,12 +235,18 @@ export default function Discover() {
 
       {/* Tabs */}
       <Tabs defaultValue="people" className="w-full">
-        <TabsList className="grid w-full grid-cols-2 mb-6 bg-white/70 dark:bg-midnight-100/60 backdrop-blur-sm rounded-2xl mx-4 border border-serenity-200/70 dark:border-midnight-50/30 shadow-soft">
-          <TabsTrigger value="people" className="flex items-center space-x-2 data-[state=active]:bg-serenity-600 data-[state=active]:text-white rounded-xl">
+        <TabsList className="grid w-full grid-cols-2 gap-3 mb-6 px-4">
+          <TabsTrigger
+            value="people"
+            className="flex items-center justify-center gap-2 rounded-2xl border border-serenity-200/70 bg-white/80 px-4 py-3 shadow-soft backdrop-blur-sm transition hover:border-serenity-300 data-[state=active]:border-serenity-600 data-[state=active]:bg-serenity-600 data-[state=active]:text-white"
+          >
             <UserIcon className="w-4 h-4" />
             <span>Mensen</span>
           </TabsTrigger>
-          <TabsTrigger value="styles" className="flex items-center space-x-2 data-[state=active]:bg-serenity-600 data-[state=active]:text-white rounded-xl">
+          <TabsTrigger
+            value="styles"
+            className="flex items-center justify-center gap-2 rounded-2xl border border-serenity-200/70 bg-white/80 px-4 py-3 shadow-soft backdrop-blur-sm transition hover:border-serenity-300 data-[state=active]:border-serenity-600 data-[state=active]:bg-serenity-600 data-[state=active]:text-white"
+          >
             <Palette className="w-4 h-4" />
             <span>Stijlen</span>
           </TabsTrigger>


### PR DESCRIPTION
## Summary
- restyle the Discover page tabs so each trigger has its own rounded container with hover and active states

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930c4390958832fa26803ab76370c95)