### PR TITLE
Center header navigation and simplify branding

### DIFF
--- a/Layout.jsx
+++ b/Layout.jsx
@@ -72,53 +72,49 @@ export default function Layout({ children, currentPageName }) {
 
       <header className="sticky top-0 z-40 backdrop-blur-xl bg-white/80 dark:bg-midnight-100/60 border-b border-serenity-200/60 dark:border-midnight-50/30 shadow-soft">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center h-16 gap-4 sm:gap-6 justify-between">
-            <div className="flex items-center gap-6 sm:gap-8 flex-1 min-w-0">
-              <Link to={PAGE_ROUTES.timeline} className="flex items-center gap-3 flex-shrink-0">
-                <div className="h-10 w-10 rounded-2xl bg-gradient-to-br from-serenity-500 to-serenity-600 text-white flex items-center justify-center shadow-floating">
-                  <LayoutGrid className="w-5 h-5" />
-                </div>
-                <div>
-                  <p className="text-xs uppercase tracking-[0.2em] text-serenity-600 dark:text-serenity-200">Exhibit</p>
-                  <p className="font-semibold text-lg text-midnight-900 dark:text-white">Creatieve community</p>
-                </div>
-              </Link>
+          <div className="flex flex-col sm:flex-row items-center h-auto sm:h-16 gap-3 sm:gap-6 justify-center py-3 sm:py-0">
+            <Link
+              to={PAGE_ROUTES.timeline}
+              className="flex items-center gap-3 flex-shrink-0 rounded-2xl bg-gradient-to-br from-serenity-500 to-serenity-600 text-white p-2 shadow-floating"
+              aria-label="Terug naar galerij"
+            >
+              <LayoutGrid className="w-6 h-6" />
+            </Link>
 
-              <nav className="flex items-center gap-1 sm:gap-2 flex-wrap">
-                <Link to={PAGE_ROUTES.timeline}>
-                  <Button
-                    variant="ghost"
-                    className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
-                  >
-                    Galerij
-                  </Button>
-                </Link>
-                <Link to={PAGE_ROUTES.discover}>
-                  <Button
-                    variant="ghost"
-                    className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
-                  >
-                    Ontdekken
-                  </Button>
-                </Link>
-                <Link to={PAGE_ROUTES.community}>
-                  <Button
-                    variant="ghost"
-                    className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
-                  >
-                    Community
-                  </Button>
-                </Link>
-                <Link to={PAGE_ROUTES.profile}>
-                  <Button
-                    variant="ghost"
-                    className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
-                  >
-                    Profiel
-                  </Button>
-                </Link>
-              </nav>
-            </div>
+            <nav className="flex items-center gap-1 sm:gap-2 flex-wrap justify-center">
+              <Link to={PAGE_ROUTES.timeline}>
+                <Button
+                  variant="ghost"
+                  className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
+                >
+                  Galerij
+                </Button>
+              </Link>
+              <Link to={PAGE_ROUTES.discover}>
+                <Button
+                  variant="ghost"
+                  className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
+                >
+                  Ontdekken
+                </Button>
+              </Link>
+              <Link to={PAGE_ROUTES.community}>
+                <Button
+                  variant="ghost"
+                  className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
+                >
+                  Community
+                </Button>
+              </Link>
+              <Link to={PAGE_ROUTES.profile}>
+                <Button
+                  variant="ghost"
+                  className="rounded-full px-4 py-2 text-sm font-semibold text-midnight-900 dark:text-white hover:bg-serenity-100/70 dark:hover:bg-midnight-50/20"
+                >
+                  Profiel
+                </Button>
+              </Link>
+            </nav>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- simplify header branding by keeping only the icon and removing textual site name
- center navigation buttons across breakpoints with responsive flex layout

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69313a4304d0832f931865e8c328bdc3)